### PR TITLE
PR-6 through PR-9

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -41,7 +41,7 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" class="h-100"></div>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,7 @@ class App extends Component {
         updatedEmail: '',
         updatedPassword: '',
       },
-      config: {},
+      config: { install: {}, links: [], posts: [], rules: {} },
     };
 
     this.setContext = this.setContext.bind(this);

--- a/client/src/components/home.jsx
+++ b/client/src/components/home.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Container, Row, Col } from 'react-bootstrap';
 import Yells from './yellbox';
 import News from './newsbox';
 
@@ -7,10 +8,12 @@ function Home(props) {
   const { posts } = props;
 
   return (
-    <div className="gm_home">
-      <Yells />
-      {posts && <News posts={posts} />}
-    </div>
+    <Row noGutters className="h-100">
+      <Col xs={12} lg={4}>
+        <Yells className="my-3 my-lg-0" />
+      </Col>
+      <Col>{posts && <News posts={posts} />}</Col>
+    </Row>
   );
 }
 

--- a/client/src/components/home.jsx
+++ b/client/src/components/home.jsx
@@ -1,10 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Yells from './yellbox';
 import News from './newsbox';
 
-export default ({ posts }) => (
-  <div className="gm_home">
-    <Yells />
-    {posts && <News posts={posts} />}
-  </div>
-);
+function Home(props) {
+  const { posts } = props;
+
+  return (
+    <div className="gm_home">
+      <Yells />
+      {posts && <News posts={posts} />}
+    </div>
+  );
+}
+
+Home.propTypes = {
+  posts: PropTypes.arrayOf(
+    PropTypes.shape({
+      author: PropTypes.string,
+      data: PropTypes.string,
+      message: PropTypes.string,
+      title: PropTypes.string,
+    })
+  ),
+};
+
+Home.defaultProps = {
+  posts: [],
+};
+
+export default Home;

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -1,40 +1,105 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Segment, Container, Divider } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 
-export default ({ info }) => (
+function install(props) {
+  const { info } = props;
+
+  return (
     <Segment className="gm_install">
-        <Container textAlign='justified'>
-            <h3>Account Registration</h3>
-            <p>
-                You'll need to follow one of the sections below to get Eden setup to play.
-                But you'll also need to register an account on the website.
-                You can do that via the <Link to="/tools?user=register">tools page</Link>.
-            </p>
-            <Divider />
-            <h3>Fresh Install 64-bit systems</h3>
-            <p>
-                First, you'll need to <a href={info.source1} rel="noopener noreferrer" target="_blank">download the Eden Installer v4.1</a> to connect to Eden.
-                You do not need to install retail FFXI first—this install will take care of everything.
-            </p>
-            <p>
-                The files included in this installer were downloaded directly from SquareEnix's freely distributed client.
-                If the first link is full you can use the <a href={info.source2} rel="noopener noreferrer" target="_blank">alternative download.</a>
-            </p>
-            <Divider />
-            <h3>Coming back / migrating from another private server</h3>
-            <p>
-                You will need to download <a href={info.bootloader} rel="noopener noreferrer" target="_blank">our modified bootloader</a>. You may want to visit our tech-support channel on <a href={info.discord} rel="noopener noreferrer" target="_blank">our Discord server</a> if you're having trouble.
-            </p>
-            <ul>
-                <li>You can run the bootloader by itself to play on Eden but I suggest to use Ashita.</li>
-                <li>We do not officially support Windower, but you may find some help getting it set up in our tech-support channel.</li>
-                <li>Move <b>edenxi.exe</b> to your Ashita <b>ffxi-bootmod</b> directory. The default folder for this is <b>~\\Program Files (x86)\PlayOnline\Ashita\ffxi-bootmod</b></li>
-                <li>DO NOT rename <b>edenxi.exe</b> or it will not work</li>
-                <li>Open your Ashita configuration but right clicking a profile and then clicking "Edit configuration"</li>
-                <li>In the File section you will see something like <b>.\\ffxi-bootmod\\pol.exe</b>. Ensure that this is changed to <b>.\\ffxi-bootmod\\edenxi.exe</b></li>
-                <li>Command should include <b>--server play.edenxi.com --hairpin</b> and may optionally include <b>--user MYUSERNAME --pass MYPASSWORD</b> arguments so that you can automatically login.</li>
-            </ul>
-        </Container>
+      <Container textAlign="justified">
+        <h3>Account Registration</h3>
+        <p>
+          You&apos;ll need to follow one of the sections below to get Eden setup
+          to play. But you&apos;ll also need to register an account on the
+          website. You can do that via the{' '}
+          <Link to="/tools?user=register">tools page</Link>.
+        </p>
+        <Divider />
+        <h3>Fresh Install 64-bit systems</h3>
+        <p>
+          First, you&apos;ll need to{' '}
+          <a href={info.source1} rel="noopener noreferrer" target="_blank">
+            download the Eden Installer v4.1
+          </a>{' '}
+          to connect to Eden. You do not need to install retail FFXI first—this
+          install will take care of everything.
+        </p>
+        <p>
+          The files included in this installer were downloaded directly from
+          SquareEnix&apos;s freely distributed client. If the first link is full
+          you can use the{' '}
+          <a href={info.source2} rel="noopener noreferrer" target="_blank">
+            alternative download.
+          </a>
+        </p>
+        <Divider />
+        <h3>Coming back / migrating from another private server</h3>
+        <p>
+          You will need to download{' '}
+          <a href={info.bootloader} rel="noopener noreferrer" target="_blank">
+            our modified bootloader
+          </a>
+          . You may want to visit our tech-support channel on{' '}
+          <a href={info.discord} rel="noopener noreferrer" target="_blank">
+            our Discord server
+          </a>{' '}
+          if you&apos;re having trouble.
+        </p>
+        <ul>
+          <li>
+            You can run the bootloader by itself to play on Eden but I suggest
+            to use Ashita.
+          </li>
+          <li>
+            We do not officially support Windower, but you may find some help
+            getting it set up in our tech-support channel.
+          </li>
+          <li>
+            Move <b>edenxi.exe</b> to your Ashita <b>ffxi-bootmod</b> directory.
+            The default folder for this is{' '}
+            <b>~\\Program Files (x86)\PlayOnline\Ashita\ffxi-bootmod</b>
+          </li>
+          <li>
+            DO NOT rename <b>edenxi.exe</b> or it will not work
+          </li>
+          <li>
+            Open your Ashita configuration but right clicking a profile and then
+            clicking &quot;Edit configuration&quot;
+          </li>
+          <li>
+            In the File section you will see something like{' '}
+            <b>.\\ffxi-bootmod\\pol.exe</b>. Ensure that this is changed to{' '}
+            <b>.\\ffxi-bootmod\\edenxi.exe</b>
+          </li>
+          <li>
+            Command should include <b>--server play.edenxi.com --hairpin</b> and
+            may optionally include <b>--user MYUSERNAME --pass MYPASSWORD</b>{' '}
+            arguments so that you can automatically login.
+          </li>
+        </ul>
+      </Container>
     </Segment>
-);
+  );
+}
+
+install.propTypes = {
+  info: PropTypes.shape({
+    bootloader: PropTypes.string.isRequired,
+    discord: PropTypes.string.isRequired,
+    source1: PropTypes.string.isRequired,
+    source2: PropTypes.string.isRequired,
+  }),
+};
+
+install.defaultProps = {
+  info: {
+    bootloader: '',
+    discord: '',
+    source1: '',
+    source2: '',
+  },
+};
+
+export default install;

--- a/client/src/components/links.jsx
+++ b/client/src/components/links.jsx
@@ -1,16 +1,37 @@
 import React from 'react';
 import { Card, Image } from 'semantic-ui-react';
 
-export default ({ links }) => (
+import PropTypes from 'prop-types';
+
+function Links(props) {
+  const { links } = props;
+
+  return (
     <Card.Group className="gm_links" centered itemsPerRow={3}>
-        {links.map(link => (
-            <Card href={link.url}>
-                <Card.Content>
-                    {link.image && <Image floated="right" size="mini" src={link.image} />}
-                    <Card.Header>{link.header}</Card.Header>
-                    <Card.Description>{link.description}</Card.Description>
-                </Card.Content>
-            </Card>
-        ))}
+      {links.map(link => (
+        <Card key={link.url} href={link.url}>
+          <Card.Content>
+            {link.image && (
+              <Image floated="right" size="mini" src={link.image} />
+            )}
+            <Card.Header>{link.header}</Card.Header>
+            <Card.Description>{link.description}</Card.Description>
+          </Card.Content>
+        </Card>
+      ))}
     </Card.Group>
-);
+  );
+}
+
+Links.propTypes = {
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      header: PropTypes.string,
+      image: PropTypes.string,
+      url: PropTypes.string,
+    })
+  ).isRequired,
+};
+
+export default Links;

--- a/client/src/components/links.jsx
+++ b/client/src/components/links.jsx
@@ -31,7 +31,11 @@ Links.propTypes = {
       image: PropTypes.string,
       url: PropTypes.string,
     })
-  ).isRequired,
+  ),
+};
+
+Links.defaultProps = {
+  links: [],
 };
 
 export default Links;

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -56,7 +56,7 @@ const Page = props => {
         <Route
           exact
           path="/rules"
-          render={props => <Rules list={config.rules} {...props} />}
+          render={() => <Rules list={config.rules} />}
         />
         <Route exact path="/about" render={About} />
         <Route

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -43,9 +43,7 @@ const Page = props => {
         <Route
           exact
           path="/install"
-          render={() => (
-            <Install info={config.install ? config.install : null} />
-          )}
+          render={() => <Install info={config.install} />}
         />
         <Route exact path="/tools" render={() => <Tools />} />
         <Route
@@ -62,9 +60,7 @@ const Page = props => {
         <Route
           exact
           path="/home"
-          render={props => (
-            <Home posts={config.posts ? config.posts : null} {...props} />
-          )}
+          render={() => <Home posts={config.posts} />}
         />
         <Route exact path="/contact" render={() => <Contact />} />
         <Redirect from="/" to={localStorage.getItem('page') || '/home'} />
@@ -88,7 +84,7 @@ Page.propTypes = {
       discord: PropTypes.string.isRequired,
       source1: PropTypes.string.isRequired,
       source2: PropTypes.string.isRequired,
-    }).isRequired,
+    }),
     links: PropTypes.arrayOf(
       PropTypes.shape({
         description: PropTypes.string,
@@ -96,7 +92,7 @@ Page.propTypes = {
         image: PropTypes.string,
         url: PropTypes.string,
       })
-    ).isRequired,
+    ),
     posts: PropTypes.arrayOf(
       PropTypes.shape({
         author: PropTypes.string,
@@ -104,7 +100,7 @@ Page.propTypes = {
         message: PropTypes.string,
         title: PropTypes.string,
       })
-    ).isRequired,
+    ),
     rules: PropTypes.shape({
       allowed: PropTypes.arrayOf(PropTypes.string),
       disallowed: PropTypes.arrayOf(PropTypes.string),

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -51,7 +51,7 @@ const Page = props => {
         <Route
           exact
           path="/links"
-          render={props => <Links links={config.links} {...props} />}
+          render={() => <Links links={config.links} />}
         />
         <Route
           exact

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -22,7 +22,7 @@ const Page = props => {
   };
 
   return (
-    <div className="gm_main">
+    <div className="gm_main h-100">
       <div className="gm_banner">
         <Hamburger active={active} toggle={() => setActive(!active)} />
         <h2 className="gm_banner_text">Eden</h2>

--- a/client/src/components/rules.jsx
+++ b/client/src/components/rules.jsx
@@ -1,47 +1,152 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Message } from 'semantic-ui-react';
 
-const Rules = ({ list }) => {
-    const { terms, rules, disallowed, allowed, yells, discord } = list;
+const Rules = props => {
+  const { list } = props;
+  const { terms, rules, disallowed, allowed, yells, discord } = list;
 
-    return (
-        <React.Fragment>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Terms and Conditions</h3></Message.Header>
-                <ol>{terms.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Formal Rules</h3></Message.Header>
-                <p>Listed here is a list of formal rules. It will be expanded upon and modified in the future so please stay as current as realistically possible with them. If you see someone breaking the rules, <b><u>please do not report them in public forums like Discord</u></b>. Either let them know they should stop, or call a GM using the in game Help Desk. Staff takes these reports seriously and we follow up on each one, but we do not want anybody shamed publicly for things they are simply suspected of. Once staff concludes if they are cheating or not, we will take appropriate action.</p>
-                <p>Regarding behavior: we don't have an all inclusive code of conduct manual for you to read so use common sense. If you are doing something that would have gotten you banned or in trouble on retail, it is more than likely against the rules here too. If you are doing inappropriate things that you wouldn't do to your friends--I would think twice about that too. Finally, if a GM asks you to stop a behavior--saying "it isn't in the rules" is not a valid excuse for ignoring the GM. </p>
-                <p>We give our GMs the responsibility to uphold rules in the essence of fair play as well as to ensure that other's play experience is not effected negatively, not all rules will be listed as some must be handled on a case by case basis, Our GM staff upholds communication between themselves in order to ensure a consistency in policy and has measures to ensure that this does not get abused, <b>ALL GM requests must be upheld and if something is found to be wrong with a certain request it will be dealt with accordingly. In the event you feel a GM's judgement was off you may contact a council member via webform on the website tools</b></p>
-                <ol>{rules.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Disallowed third-party software</h3></Message.Header>
-                <p>A list of disallowed plugins and other third-party software. This is not an exhastive list, to be absolutely safe stick the the approved list or ask a staff member to update the list. Ashita and its plugins are listed first but Windower and its addon/plugin alternative are also disallowed.</p>
-                <ol>{disallowed.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Allowed third-party software</h3></Message.Header>
-                <p>A list of allowed plugins and other third-party software.</p>
-                <ol>{allowed.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Yell Rules</h3></Message.Header>
-                <ol>{yells.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Discord Rules</h3></Message.Header>
-                <ol>{discord.map((t, i) => <li key={`term_${i}`}>{t}</li>)}</ol>
-            </Message>
-            <Message className="gm_rules-section">
-                <Message.Header><h3 className="gm_news-title">Remarks</h3></Message.Header>
-                <p>We want to promote a server that promotes teamwork first and foremost. Many of our development decisions including removing some quality of life enhancements are based on this tenant. We know some things can be annoying and time consuming but we feel like some of those things are unavoidable to provide a stronger feeling of community. Please report to the administration when you think there is something that we overlooked and would rather not have or rather have in the game.</p>
-                <p>While not a rule, we would like to see stronger players encouraging and helping newer and weaker players in the form of: inviting them into your experience point parties, sharing non-secret information about monsters and drops, and more. When more people feel welcomed to this server we will all prosper.</p>
-            </Message>
-        </React.Fragment>
-    );
+  return (
+    <>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Terms and Conditions</h3>
+        </Message.Header>
+        <ol>
+          {terms.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Formal Rules</h3>
+        </Message.Header>
+        <p>
+          Listed here is a list of formal rules. It will be expanded upon and
+          modified in the future so please stay as current as realistically
+          possible with them. If you see someone breaking the rules,{' '}
+          <b>
+            <u>please do not report them in public forums like Discord</u>
+          </b>
+          . Either let them know they should stop, or call a GM using the in
+          game Help Desk. Staff takes these reports seriously and we follow up
+          on each one, but we do not want anybody shamed publicly for things
+          they are simply suspected of. Once staff concludes if they are
+          cheating or not, we will take appropriate action.
+        </p>
+        <p>
+          Regarding behavior: we don&apos;t have an all inclusive code of
+          conduct manual for you to read so use common sense. If you are doing
+          something that would have gotten you banned or in trouble on retail,
+          it is more than likely against the rules here too. If you are doing
+          inappropriate things that you wouldn&apos;t do to your friends--I
+          would think twice about that too. Finally, if a GM asks you to stop a
+          behavior--saying &quot;it isn&apos;t in the rules&quot; is not a valid
+          excuse for ignoring the GM.
+        </p>
+        <p>
+          We give our GMs the responsibility to uphold rules in the essence of
+          fair play as well as to ensure that other&apos;s play experience is
+          not effected negatively, not all rules will be listed as some must be
+          handled on a case by case basis, Our GM staff upholds communication
+          between themselves in order to ensure a consistency in policy and has
+          measures to ensure that this does not get abused,{' '}
+          <b>
+            ALL GM requests must be upheld and if something is found to be wrong
+            with a certain request it will be dealt with accordingly. In the
+            event you feel a GM&apos;s judgement was off you may contact a
+            council member via webform on the website tools
+          </b>
+        </p>
+        <ol>
+          {rules.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Disallowed third-party software</h3>
+        </Message.Header>
+        <p>
+          A list of disallowed plugins and other third-party software. This is
+          not an exhastive list, to be absolutely safe stick the the approved
+          list or ask a staff member to update the list. Ashita and its plugins
+          are listed first but Windower and its addon/plugin alternative are
+          also disallowed.
+        </p>
+        <ol>
+          {disallowed.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Allowed third-party software</h3>
+        </Message.Header>
+        <p>A list of allowed plugins and other third-party software.</p>
+        <ol>
+          {allowed.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Yell Rules</h3>
+        </Message.Header>
+        <ol>
+          {yells.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Discord Rules</h3>
+        </Message.Header>
+        <ol>
+          {discord.map((t, i) => (
+            <li key={`term_${i}`}>{t}</li>
+          ))}
+        </ol>
+      </Message>
+      <Message className="gm_rules-section">
+        <Message.Header>
+          <h3 className="gm_news-title">Remarks</h3>
+        </Message.Header>
+        <p>
+          We want to promote a server that promotes teamwork first and foremost.
+          Many of our development decisions including removing some quality of
+          life enhancements are based on this tenant. We know some things can be
+          annoying and time consuming but we feel like some of those things are
+          unavoidable to provide a stronger feeling of community. Please report
+          to the administration when you think there is something that we
+          overlooked and would rather not have or rather have in the game.
+        </p>
+        <p>
+          While not a rule, we would like to see stronger players encouraging
+          and helping newer and weaker players in the form of: inviting them
+          into your experience point parties, sharing non-secret information
+          about monsters and drops, and more. When more people feel welcomed to
+          this server we will all prosper.
+        </p>
+      </Message>
+    </>
+  );
+};
+
+Rules.propTypes = {
+  list: PropTypes.shape({
+    allowed: PropTypes.arrayOf(PropTypes.string),
+    disallowed: PropTypes.arrayOf(PropTypes.string),
+    discord: PropTypes.arrayOf(PropTypes.string),
+    rules: PropTypes.arrayOf(PropTypes.string),
+    terms: PropTypes.arrayOf(PropTypes.string),
+    yells: PropTypes.arrayOf(PropTypes.string),
+  }).isRequired,
 };
 
 export default Rules;

--- a/client/src/components/rules.jsx
+++ b/client/src/components/rules.jsx
@@ -146,7 +146,18 @@ Rules.propTypes = {
     rules: PropTypes.arrayOf(PropTypes.string),
     terms: PropTypes.arrayOf(PropTypes.string),
     yells: PropTypes.arrayOf(PropTypes.string),
-  }).isRequired,
+  }),
+};
+
+Rules.defaultProps = {
+  list: {
+    allowed: [],
+    disallowed: [],
+    discord: [],
+    rules: [],
+    terms: [],
+    yells: [],
+  },
 };
 
 export default Rules;

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -1,249 +1,246 @@
 /* Banner */
 
 .gm_banner {
-    background: url(../assets/banner.jpg) no-repeat center center;
-    background-size: cover;
-    border-bottom: 2px solid #060606;
-    border-top: 2px solid #060606;
-    box-shadow: inset 0 0 15px 0 #111, inset 0 0 15px 0 #111;
-    height: 55px;
-    min-width: 400px;
-    position: relative;
+  background: url(../assets/banner.jpg) no-repeat center center;
+  background-size: cover;
+  border-bottom: 2px solid #060606;
+  border-top: 2px solid #060606;
+  box-shadow: inset 0 0 15px 0 #111, inset 0 0 15px 0 #111;
+  height: 55px;
+  position: relative;
 }
 
 .gm_banner_text {
-    color: #F8F8FF;
-    display: block;
-    font-family: 'Ruslan Display','Trebuchet MS','Lucida Sans Unicode','Lucida Grande','Lucida Sans',Arial,sans-serif;
-    font-size: 4em;
-    font-weight: bold;
-    letter-spacing: -0.25rem;
-    margin: 0;
-    text-align: center;
-    text-decoration: none;
-    text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9, 0 5px 0 #aaa, 0 6px 1px rgba(0,0,0,0.1), 0 0 5px rgba(0,0,0,0.1), 0 1px 3px rgba(0,0,0,0.3), 0 3px 5px rgba(0,0,0,0.2), 0 5px 10px rgba(0,0,0,0.25), 0 10px 10px rgba(25,200,255,0.4), 0 20px 20px rgba(0,0,0,0.15);
-    position: absolute;
-    bottom: -1rem;
-    right: 1rem;
-    user-select: none;
+  color: #f8f8ff;
+  display: block;
+  font-family: 'Ruslan Display', 'Trebuchet MS', 'Lucida Sans Unicode',
+    'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
+  font-size: 4em;
+  font-weight: bold;
+  letter-spacing: -0.25rem;
+  margin: 0;
+  text-align: center;
+  text-decoration: none;
+  text-shadow: 0 1px 0 #ccc, 0 2px 0 #c9c9c9, 0 3px 0 #bbb, 0 4px 0 #b9b9b9,
+    0 5px 0 #aaa, 0 6px 1px rgba(0, 0, 0, 0.1), 0 0 5px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.3), 0 3px 5px rgba(0, 0, 0, 0.2),
+    0 5px 10px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(25, 200, 255, 0.4),
+    0 20px 20px rgba(0, 0, 0, 0.15);
+  position: absolute;
+  bottom: -1rem;
+  right: 1rem;
+  user-select: none;
 }
 
 /* Menu */
 
 .gm_menu.ui.menu {
-    margin: 1rem;
-    position: absolute;
-    z-index: 1;
+  margin: 1rem;
+  position: absolute;
+  z-index: 1;
 }
 
 .gm_menu-credits {
-    
 }
 
 /* Home section */
 
-.gm_home {
-    width: 100%;
-    display: flex;
-}
-
 .gm_news-container {
-    height: calc(100vh - 55px);
-    overflow: auto;
-    padding: 1rem;
-    margin: 0;
-    flex: 1;
-    list-style: none;
+  overflow: auto;
+  padding: 1rem;
+  margin: 0;
+  flex: 1;
+  list-style: none;
 }
 
 .ui.message.gm_news-post p.gm_news-date {
-    margin-top: 0;
-    margin-bottom: 1em;
-    font-size: .75em;
+  margin-top: 0;
+  margin-bottom: 1em;
+  font-size: 0.75em;
 }
 
 .gm_news-title {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 /* Yellbox */
 
 .gm_yell-container {
-    color: white;
-    overflow: auto;
-    background-color: #120D37;
-    margin: 0;
-    height: calc(100vh - 55px);
-    width: 400px;
-    min-height: 150px;
-    display: flex;
-    padding: 1rem;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-start;
-    user-select: none;
-    list-style: none;
+  min-height: 15vh;
+  color: white;
+  overflow: auto;
+  background-color: #120d37;
+  margin: 0;
+  display: flex;
+  padding: 1rem;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  user-select: none;
+  list-style: none;
 }
 
 .gm_yell-name {
-    color: #7AF;
+  color: #7af;
 }
 
 .gm_yell-text {
-    color: white;
+  color: white;
 }
 
 /* Tools */
 
 .gm_tools {
-    margin: 1rem;
-    display: flex;
+  margin: 1rem;
+  display: flex;
 }
 
 .eden_pagination-dropdown {
-    margin: 4px;
+  margin: 4px;
 }
 
 .gm_whosonline {
-    display: flex;
-    flex-direction: column;
-    width: 300px;
-    max-height: calc(100vh - 2rem - 55px);
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+  max-height: calc(100vh - 2rem - 55px);
 }
 
 .gm_players-online {
-    max-height: 80%;
-    overflow: auto;
+  max-height: 80%;
+  overflow: auto;
 }
 
 .gm_profile-buttons {
-    margin-top: 1rem;
+  margin-top: 1rem;
 }
 
 .gm_linkshell {
-    margin-left: 6px;
-    display: flex;
-    font-size: 14px;
+  margin-left: 6px;
+  display: flex;
+  font-size: 14px;
 }
 
 .gm_online-avatar.ui.image {
-    border-radius: 50%;
+  border-radius: 50%;
 }
 
 .gm_online-count.ui.segments {
-    margin: 0 .5em 1rem .5em;
+  margin: 0 0.5em 1rem 0.5em;
 }
 
 .gm_tools-content {
-    flex: 1;
-    padding: 0 1rem;
-    max-height: calc(100vh - 3rem - 55px);
-    overflow: hidden;
+  flex: 1;
+  padding: 0 1rem;
+  max-height: calc(100vh - 3rem - 55px);
+  overflow: hidden;
 }
 
 .gm_tools-container {
-    height: calc(100% - 4rem);
-    max-height: calc(100% - 4rem);
-    overflow: auto;
+  height: calc(100% - 4rem);
+  max-height: calc(100% - 4rem);
+  overflow: auto;
 }
 
 .gm_item-header {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .gm_item-header-button.ui.blue.basic.button.active {
-    background-color: #2185D0 !important;
-    color: #FFF !important;
+  background-color: #2185d0 !important;
+  color: #fff !important;
 }
 
 .gm_item-name {
-    display: inline-flex;
-    align-items: center;
+  display: inline-flex;
+  align-items: center;
 }
 
-.gm_itemsearch_row.ui.segment.item, .gm_charsearch_row.ui.segment.item {
-    padding: 5px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
+.gm_itemsearch_row.ui.segment.item,
+.gm_charsearch_row.ui.segment.item {
+  padding: 5px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .gm_itemsearch_row.ui.segment.item:hover {
-    transform: translateY(-1px);
-    background-color: #F8F8F8;
+  transform: translateY(-1px);
+  background-color: #f8f8f8;
 }
 
 .gm_field-change.ui.modal.transition.visible.active {
-    width: 400px;
+  width: 400px;
 }
 
 .gm_player-header {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 }
 
 .gm_player-header-left {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 /* Install */
 
 .gm_install.ui.segment {
-    width: fit-content;
-    margin: 1rem auto;
-    max-width: 1200px;
+  width: fit-content;
+  margin: 1rem auto;
+  max-width: 1200px;
 }
 
 /* Rules */
 
 .ui.message.gm_rules-section {
-    margin: 2em;
+  margin: 2em;
 }
 
 /* About */
 
 .gm_code-block {
-    white-space: pre-wrap;
-    background-color: #f5f5f5;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    padding: 9.5px;
+  white-space: pre-wrap;
+  background-color: #f5f5f5;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 9.5px;
 }
 
 /* Links */
 
 .gm_links.ui.cards {
-    max-width: 800px;
-    margin: auto;
+  max-width: 800px;
+  margin: auto;
 }
 
 /* General */
 
-.ui.ui.ui img.gm_image-spacer, .ui.list>.item>.image:only-child, .ui.list>.item>img.image.gm_image-spacer {
-    margin-right: 5px;
+.ui.ui.ui img.gm_image-spacer,
+.ui.list > .item > .image:only-child,
+.ui.list > .item > img.image.gm_image-spacer {
+  margin-right: 5px;
 }
 
 @media only screen and (max-width: 900px) {
-    .gm_tools {
-        flex-direction: column;
-    }
-    .gm_whosonline {
-        width: 100%;
-    }
-    .gm_tools-content {
-        width: 100%;
-        padding: 7px;
-    }
-    .gm_players-online.ui.cards {
-        display: none;
-    }
-    .gm_item-header {
-        flex-direction: column;
-
-    }
-    .gm_item-header > * {
-        margin: 10px 0;
-    }
+  .gm_tools {
+    flex-direction: column;
+  }
+  .gm_whosonline {
+    width: 100%;
+  }
+  .gm_tools-content {
+    width: 100%;
+    padding: 7px;
+  }
+  .gm_players-online.ui.cards {
+    display: none;
+  }
+  .gm_item-header {
+    flex-direction: column;
+  }
+  .gm_item-header > * {
+    margin: 10px 0;
+  }
 }

--- a/client/src/components/yellbox.jsx
+++ b/client/src/components/yellbox.jsx
@@ -2,41 +2,44 @@ import React from 'react';
 import apiUtil from '../apiUtil';
 
 class Yells extends React.PureComponent {
-    constructor(props) {
-        super(props);
-        this.state = { yells: [] };
-        this.yells = this.yells.bind(this);
-    }
+  constructor(props) {
+    super(props);
+    this.state = { yells: [] };
+    this.yells = this.yells.bind(this);
+  }
 
-    yells() {
-        apiUtil.get({ url: '/api/v1/misc/yells', json: true }, (error, yells) => {
-            if (!error) this.setState({ yells });
-        });
-    }
+  yells() {
+    apiUtil.get({ url: '/api/v1/misc/yells', json: true }, (error, yells) => {
+      if (!error) this.setState({ yells });
+    });
+  }
 
-    componentDidMount() {
-        this.yells();
-        this.polling = setInterval(this.yells, 60000);
-    }
+  componentDidMount() {
+    this.yells();
+    this.polling = setInterval(this.yells, 60000);
+  }
 
-    componentWillUnmount() {
-        clearInterval(this.polling);
-    }
+  componentWillUnmount() {
+    clearInterval(this.polling);
+  }
 
-    render() {
-        const { yells } = this.state;
+  render() {
+    const { yells } = this.state;
 
-        return (
-            <ul className="gm_yell-container">
-                {yells.map((yell, i) => (
-                    <li key={`yell_${i}`} className="gm_yell-message">
-                        <span className="gm_yell-name">[{new Date(yell.date).toLocaleTimeString()}] {yell.speaker}</span> : &nbsp;
-                        <span className="gm_yell-text">{yell.message}</span>
-                    </li>
-                ))}
-            </ul>
-        );
-    }
-};
+    return (
+      <ul className="gm_yell-container h-100">
+        {yells.map((yell, i) => (
+          <li key={`yell_${i}`} className="gm_yell-message">
+            <span className="gm_yell-name">
+              [{new Date(yell.date).toLocaleTimeString()}] {yell.speaker}
+            </span>{' '}
+            : &nbsp;
+            <span className="gm_yell-text">{yell.message}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+}
 
 export default Yells;


### PR DESCRIPTION
Trying out bigger PRs for the current client-side PRs, as the current PR chain changes a lot of the same files, which causes merge conflicts whenever one of the previous PRs merges. 
This is causing it to take a while to get them all in, so in an effort to get this in easier/faster, this PR consolidates PR-6 through PR-9 as they had many of the same files changed.

* #19: Validate Links props and only pass necessary props.
* #20: Validate Rules props and only pass necessary props.
* #22: Add props defaults to ensure most sections of site can be viewed while API is down (more work can be done to show/hide tools as necessary in future; not having pages throw errors will help to do that work).
* #23: Make home page responsive for difference screen sizes. Previously yell box took up entire page on mobile view. Introducing Bootstrap 4 and react-bootstrap here as they are responsive by default, minimal design, come with lots of features, and allow for fast UI development particularly due to Grid and breakpoint systems. Also helps to use a common framework with site being open sourced.