### PR TITLE
Don't use /public as static path for serving files

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ const app = express();
 
 app.use(bodyParser.json());
 
-app.use('/public', express.static(path.join(__dirname, 'public')));
+app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/api', api);
 app.get('/*', (req, res) => {


### PR DESCRIPTION
This should fix the issue noted here: https://github.com/EdenServer/eden-web/pull/41#issuecomment-632961995