### PR TITLE
UI improvements

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -109,7 +109,7 @@ class App extends Component {
       <>
         <div className="gm_main h-100">
           <SiteNavbar links={links} />
-          <div className="gm_content">
+          <div className="gm_content my-3">
             {config && Object.keys(config).length === 0 && (
               <div className="alert alert-warning m-0 text-center">
                 <span>

--- a/client/src/components/InfoDisplay.jsx
+++ b/client/src/components/InfoDisplay.jsx
@@ -3,19 +3,16 @@ import PropTypes from 'prop-types';
 import Card from 'react-bootstrap/Card';
 
 function InfoDisplay(props) {
-  const { header, title, children, footer } = props;
+  const { title, children, footer } = props;
 
   return (
     <Card bg="light">
-      {header && <Card.Header>{header}</Card.Header>}
-      <Card.Body>
-        {title && (
-          <Card.Title>
-            <h3>{title}</h3>
-          </Card.Title>
-        )}
-        {children}
-      </Card.Body>
+      {title && (
+        <Card.Header>
+          <h3>{title}</h3>
+        </Card.Header>
+      )}
+      <Card.Body>{children}</Card.Body>
       {footer && (
         <Card.Footer className="text-muted text-right">{footer}</Card.Footer>
       )}
@@ -24,14 +21,12 @@ function InfoDisplay(props) {
 }
 
 InfoDisplay.propTypes = {
-  header: PropTypes.node,
   title: PropTypes.string,
   children: PropTypes.node.isRequired,
   footer: PropTypes.node,
 };
 
 InfoDisplay.defaultProps = {
-  header: null,
   title: '',
   footer: null,
 };

--- a/client/src/components/SiteFooter/SiteFooter.jsx
+++ b/client/src/components/SiteFooter/SiteFooter.jsx
@@ -7,7 +7,7 @@ const SiteFooter = () => {
       <Row>
         <Col xs={12} lg className="my-auto">
           <p className="h4 p-3">
-            <b>EDEN</b> | Classic FFXI Server
+            <b>EDEN</b> | Classic FFXI Emulation Server
           </p>
         </Col>
         <Col xs={12} lg className="my-auto">

--- a/client/src/components/about/index.jsx
+++ b/client/src/components/about/index.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import Card from 'react-bootstrap/Card';
 import InfoDisplay from '../InfoDisplay';
 import Contributing from './contributing';
-import { Container, Row, Col } from 'react-bootstrap';
+import { Row, Col } from 'react-bootstrap';
 
 const About = () => {
   return (
-    <Container>
+    <>
       <Row className="mb-3">
         <Col>
           <InfoDisplay
@@ -190,7 +190,7 @@ const About = () => {
           </InfoDisplay>
         </Col>
       </Row>
-    </Container>
+    </>
   );
 };
 

--- a/client/src/components/home.jsx
+++ b/client/src/components/home.jsx
@@ -8,14 +8,9 @@ function Home(props) {
   const { posts } = props;
 
   return (
-    <Container fluid>
-      <Row className="min-vh-100" className="flex-column-reverse flex-lg-row">
-        <Col>{posts && <News posts={posts} />}</Col>
-        <Col xs={12} lg={5} className="mb-3 mb-lg-0">
-          <Yells />
-        </Col>
-      </Row>
-    </Container>
+    <Row className="min-vh-100" className="flex-column-reverse flex-lg-row">
+      <Col>{posts && <News posts={posts} />}</Col>
+    </Row>
   );
 }
 

--- a/client/src/components/home.jsx
+++ b/client/src/components/home.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col, Container } from 'react-bootstrap';
-import Yells from './yellbox';
+import { Row, Col } from 'react-bootstrap';
+import YellBox from './yellbox';
 import News from './newsbox';
 
 function Home(props) {
   const { posts } = props;
 
   return (
-    <Row className="min-vh-100" className="flex-column-reverse flex-lg-row">
+    <Row className="min-vh-100 flex-column-reverse flex-lg-row">
       <Col>{posts && <News posts={posts} />}</Col>
+      <Col lg={4} className="mb-3 mb-lg-0">
+        <YellBox />
+      </Col>
     </Row>
   );
 }

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -8,7 +8,7 @@ function install(props) {
   const { info } = props;
 
   return (
-    <Container>
+    <>
       <Row className="mb-3">
         <Col>
           <InfoDisplay title="Account Registration">
@@ -109,7 +109,7 @@ function install(props) {
           </InfoDisplay>
         </Col>
       </Row>
-    </Container>
+    </>
   );
 }
 

--- a/client/src/components/links.jsx
+++ b/client/src/components/links.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Container, Row, Col, Card } from 'react-bootstrap';
+import { Row, Col, Card } from 'react-bootstrap';
 
 import PropTypes from 'prop-types';
 
@@ -7,36 +7,34 @@ function Links(props) {
   const { links } = props;
 
   return (
-    <Container>
-      <Row>
-        {links.map(link => (
-          <Col xs={12} md={6} xl={3} className="my-2 my-md-3" key={link.url}>
-            <Card className="h-100 link-card">
-              <Card.Header>
-                <div className="d-flex flex-row justify-content-between">
-                  <Card.Title>
-                    <a
-                      href={link.url}
-                      className="stretched-link text-dark"
-                      style={{ textDecoration: 'none' }}
-                    >
-                      {link.header}
-                    </a>
-                  </Card.Title>
-                  {link.image && (
-                    <img alt="" src={link.image} style={{ maxWidth: '35px' }} />
-                  )}
-                </div>
-              </Card.Header>
-              <Card.Body>
-                <Card.Text>{link.description}</Card.Text>
-                <Card.Link />
-              </Card.Body>
-            </Card>
-          </Col>
-        ))}
-      </Row>
-    </Container>
+    <Row>
+      {links.map(link => (
+        <Col xs={12} md={6} xl={4} className="my-2 my-md-3" key={link.url}>
+          <Card className="h-100 link-card">
+            <Card.Header>
+              <div className="d-flex flex-row justify-content-between">
+                <Card.Title>
+                  <a
+                    href={link.url}
+                    className="stretched-link text-dark"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    {link.header}
+                  </a>
+                </Card.Title>
+                {link.image && (
+                  <img alt="" src={link.image} style={{ maxWidth: '35px' }} />
+                )}
+              </div>
+            </Card.Header>
+            <Card.Body>
+              <Card.Text>{link.description}</Card.Text>
+              <Card.Link />
+            </Card.Body>
+          </Card>
+        </Col>
+      ))}
+    </Row>
   );
 }
 

--- a/client/src/components/links.jsx
+++ b/client/src/components/links.jsx
@@ -9,7 +9,7 @@ function Links(props) {
   return (
     <Row>
       {links.map(link => (
-        <Col xs={12} md={6} xl={4} className="my-2 my-md-3" key={link.url}>
+        <Col xs={12} md={6} xl={3} className="my-2 my-md-3" key={link.url}>
           <Card className="h-100 link-card">
             <Card.Header>
               <div className="d-flex flex-row justify-content-between">

--- a/client/src/components/newsbox.jsx
+++ b/client/src/components/newsbox.jsx
@@ -10,7 +10,7 @@ const News = ({ posts }) => (
         className={i === 0 || i === posts.length - 1 ? '' : 'my-3'}
       >
         <InfoDisplay
-          header={<h2>{post.title}</h2>}
+          title={post.title}
           footer={
             <span>
               {new Date(post.date).toLocaleString()} by {post.author}

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Router, Redirect } from '@reach/router';
+import { Container, Row, Col } from 'react-bootstrap';
 import Home from './home';
 import Install from './install';
 import Links from './links';
@@ -9,14 +10,13 @@ import Rules from './rules';
 import About from './about';
 import Contact from './contact';
 import './style.css';
-import { Container, Row, Col } from 'react-bootstrap';
 import YellBox from './yellbox';
 
 const Page = props => {
   const { config } = props;
 
   return (
-    <Container fluid className="h-100">
+    <Container className="h-100">
       <Row className="h-100 flex-column-reverse flex-lg-row">
         <Col>
           <Router primary={false}>
@@ -28,9 +28,6 @@ const Page = props => {
             <About path="/about" />
             <Contact path="/contact" />
           </Router>
-        </Col>
-        <Col lg={4} className="mb-3 mb-lg-0">
-          <YellBox />
         </Col>
       </Row>
     </Container>

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -9,22 +9,31 @@ import Rules from './rules';
 import About from './about';
 import Contact from './contact';
 import './style.css';
+import { Container, Row, Col } from 'react-bootstrap';
+import YellBox from './yellbox';
 
 const Page = props => {
   const { config } = props;
 
   return (
-    <div>
-      <Router primary={false} className="py-3">
-        <Home path="/" posts={config.posts} />
-        <Install path="/install" info={config.install} />
-        <Tools path="/tools" />
-        <Links path="/links" links={config.links} />
-        <Rules path="/rules" list={config.rules} />
-        <About path="/about" />
-        <Contact path="/contact" />
-      </Router>
-    </div>
+    <Container fluid className="h-100">
+      <Row className="h-100 flex-column-reverse flex-lg-row">
+        <Col>
+          <Router primary={false}>
+            <Home path="/" posts={config.posts} />
+            <Install path="/install" info={config.install} />
+            <Tools path="/tools" />
+            <Links path="/links" links={config.links} />
+            <Rules path="/rules" list={config.rules} />
+            <About path="/about" />
+            <Contact path="/contact" />
+          </Router>
+        </Col>
+        <Col lg={4} className="mb-3 mb-lg-0">
+          <YellBox />
+        </Col>
+      </Row>
+    </Container>
   );
 };
 

--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -10,7 +10,6 @@ import Rules from './rules';
 import About from './about';
 import Contact from './contact';
 import './style.css';
-import YellBox from './yellbox';
 
 const Page = props => {
   const { config } = props;

--- a/client/src/components/rules.jsx
+++ b/client/src/components/rules.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Card from 'react-bootstrap/Card';
 import InfoDisplay from './InfoDisplay';
-import { Container, Row, Col } from 'react-bootstrap';
+import { Row, Col } from 'react-bootstrap';
 
 const Rules = ({ list }) => {
   const { terms, rules, disallowed, allowed, yells, discord } = list;
 
   return (
-    <Container>
+    <>
       <Row className="mb-3">
         <Col>
           <InfoDisplay title="Terms and Conditions">
@@ -153,7 +153,7 @@ const Rules = ({ list }) => {
           </InfoDisplay>
         </Col>
       </Row>
-    </Container>
+    </>
   );
 };
 

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -87,6 +87,7 @@ body {
 
 .gm_yell-container {
   min-height: 15vh;
+  max-height: 960px;
   color: white;
   overflow: auto;
   background-color: #120d37;


### PR DESCRIPTION
- Put all card titles into card header sections instead of in body.
- Show yells on all pages (more helpful than just on homepage, and makes layout consistent)
- Fix/simplify layout following above-mentioned yells change.