### PR TITLE
[Issue #58] Fix footer covering search results

### DIFF
--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -151,6 +151,8 @@ body {
 .gm_tools-content {
   flex: 1;
   padding: 0 1rem;
+  max-height: calc(100vh - 3rem - 55px);
+  overflow: hidden;
 }
 
 .gm_tools-container {

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -151,8 +151,6 @@ body {
 .gm_tools-content {
   flex: 1;
   padding: 0 1rem;
-  max-height: calc(100vh - 3rem - 55px);
-  overflow: hidden;
 }
 
 .gm_tools-container {


### PR DESCRIPTION
- Removed `max-height` and `overflow: hidden` from `.gm_tools-container` as this was cutting off visibility of tools on small screens.

Test before/after by searching i.e. "crystal" in AH tools on mobile view.