### PR TITLE
[Issue #58] Fix visibility being cut off on tools

### DIFF
--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -151,8 +151,6 @@ body {
 .gm_tools-content {
   flex: 1;
   padding: 0 1rem;
-  max-height: calc(100vh - 3rem - 55px);
-  overflow: hidden;
 }
 
 .gm_tools-container {


### PR DESCRIPTION
- Remove `max-height` and `overflow: hidden` which were cutting off the visibility of the site tools on mobile.

Test before and after by searching i.e. "crystal" in AH tools on mobile view. Before, the list was cut off at a certain point. After, the entire list is shown.