### PR TITLE
Set focus to search box for player and item tabs when they mount

### DIFF
--- a/client/src/components/tools/itemsearch.jsx
+++ b/client/src/components/tools/itemsearch.jsx
@@ -66,6 +66,11 @@ const Itemsearch = ({ history, itemname, itemstack }) => {
     if (itemname) fetchMemoizedItem(encodeURIComponent(itemname), getStack);
   }, [itemname, itemstack]);
 
+  const searchInput = React.useRef(null);
+  React.useEffect(() => {
+    searchInput.current.focus();
+  }, []);
+
   return (
     <Segment className="gm_tools-container">
       <Input
@@ -73,6 +78,7 @@ const Itemsearch = ({ history, itemname, itemstack }) => {
         placeholder="Search..."
         loading={loading}
         value={search}
+        ref={searchInput}
         onKeyUp={handleSearch}
         onChange={e => setSearch(e.target.value)}
       />

--- a/client/src/components/tools/playersearch.jsx
+++ b/client/src/components/tools/playersearch.jsx
@@ -70,6 +70,11 @@ const Playersearch = ({ history, charname }) => {
     if (charname) fetchMemoizedPlayer(charname);
   }, [charname]);
 
+  const searchInput = React.useRef(null);
+  React.useEffect(() => {
+    searchInput.current.focus();
+  }, []);
+
   return (
     <Segment className="gm_tools-container">
       <Input
@@ -77,6 +82,7 @@ const Playersearch = ({ history, charname }) => {
         placeholder="Search..."
         loading={loading}
         value={search}
+        ref={searchInput}
         onKeyUp={handleSearch}
         onChange={e => setSearch(e.target.value)}
       />


### PR DESCRIPTION
When switching to the player or item search tab, it will now automatically set focus to the search input box, so the user doesn't have to do it manually.