### PR TITLE
Improve tools navigation by utilizing the router

### DIFF
--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -21,7 +21,7 @@ const Page = props => {
           <Router primary={false}>
             <Home path="/" posts={config.posts} />
             <Install path="/install" info={config.install} />
-            <Tools path="/tools" />
+            <Tools path="/tools/*" />
             <Links path="/links" links={config.links} />
             <Rules path="/rules" list={config.rules} />
             <About path="/about" />

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Menu } from 'semantic-ui-react';
 
-import { createHistory, navigate } from '@reach/router';
+import { createHistory, Link, Router } from '@reach/router';
 import Accounts from './accounts';
 import Itemsearch from './tools/itemsearch';
 import Playersearch from './tools/playersearch';
@@ -10,58 +10,36 @@ import YellTab from './tools/YellTab';
 
 const Tools = () => {
   const history = createHistory(window);
-  const [tab, setTab] = React.useState(
-    localStorage.getItem('tools.tab') || 'account'
-  );
-  const params = new URLSearchParams(history.location.search);
-  const item = params.get('item');
-  const stack = params.get('stack');
-  const player = params.get('player');
-
-  let selected = tab;
-  if (item) selected = 'items';
-  else if (player) selected = 'chars';
-
-  const updateTab = tab => () => {
-    navigate('/tools');
-    localStorage.setItem('tools.tab', tab);
-    setTab(tab);
-  };
 
   return (
     <div className="gm_tools">
       <div className="gm_tools-content">
         <Menu pointing>
-          <Menu.Item
-            disabled
-            active={selected === 'account'}
-            onClick={updateTab('account')}
-          >
+          <Menu.Item disabled>
+            {/*as={Link} to="account" */}
             User Management
           </Menu.Item>
-          <Menu.Item
-            active={selected === 'online'}
-            onClick={updateTab('online')}
-          >
+          <Menu.Item as={Link} to="online">
             Who's Online
           </Menu.Item>
-          <Menu.Item active={selected === 'items'} onClick={updateTab('items')}>
+          <Menu.Item as={Link} to="item">
             Item Search
           </Menu.Item>
-          <Menu.Item active={selected === 'chars'} onClick={updateTab('chars')}>
+          <Menu.Item as={Link} to="player">
             Player Search
           </Menu.Item>
-          <Menu.Item active={selected === 'yells'} onClick={updateTab('yells')}>
+          <Menu.Item as={Link} to="yells">
             Yells
           </Menu.Item>
         </Menu>
-        {/* {selected === 'account' && <Accounts />} */}
-        {selected === 'online' && <OnlineList />}
-        {(item || selected === 'items') && (
-          <Itemsearch itemname={item} itemstack={stack} />
-        )}
-        {(player || selected === 'chars') && <Playersearch charname={player} />}
-        {selected === 'yells' && <YellTab />}
+        <Router>
+          <OnlineList path="/" />
+          <OnlineList path="online" />
+          {/* <Accounts path="account" /> */}
+          <Itemsearch path="item/*" history={history} />
+          <Playersearch path="player/*" history={history} />
+          <YellTab path="yells" />
+        </Router>
       </div>
     </div>
   );

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -1,36 +1,47 @@
 import React from 'react';
 import { Menu } from 'semantic-ui-react';
 
-import { createHistory, Link, Router } from '@reach/router';
+import { createHistory, Link, Router, useMatch } from '@reach/router';
 import Accounts from './accounts';
 import Itemsearch from './tools/itemsearch';
 import Playersearch from './tools/playersearch';
 import OnlineList from './tools/OnlineList';
 import YellTab from './tools/YellTab';
 
+const TabItem = ({ to, activeTab, disabled = false, children }) => (
+  <Menu.Item
+    as={disabled ? undefined : Link}
+    to={disabled ? undefined : to}
+    active={to === activeTab}
+    disabled={disabled}
+  >
+    {children}
+  </Menu.Item>
+);
+
 const Tools = () => {
   const history = createHistory(window);
+  const activeTab = useMatch(':tab/*')?.tab || 'online';
 
   return (
     <div className="gm_tools">
       <div className="gm_tools-content">
         <Menu pointing>
-          <Menu.Item disabled>
-            {/*as={Link} to="account" */}
+          <TabItem to="account" disabled={true} activeTab={activeTab}>
             User Management
-          </Menu.Item>
-          <Menu.Item as={Link} to="online">
+          </TabItem>
+          <TabItem to="online" activeTab={activeTab}>
             Who's Online
-          </Menu.Item>
-          <Menu.Item as={Link} to="item">
+          </TabItem>
+          <TabItem to="item" activeTab={activeTab}>
             Item Search
-          </Menu.Item>
-          <Menu.Item as={Link} to="player">
+          </TabItem>
+          <TabItem to="player" activeTab={activeTab}>
             Player Search
-          </Menu.Item>
-          <Menu.Item as={Link} to="yells">
+          </TabItem>
+          <TabItem to="yells" activeTab={activeTab}>
             Yells
-          </Menu.Item>
+          </TabItem>
         </Menu>
         <Router>
           <OnlineList path="/" />

--- a/client/src/components/tools/OnlineList.jsx
+++ b/client/src/components/tools/OnlineList.jsx
@@ -19,7 +19,7 @@ const OnlineTableHeader = () => (
 const PlayerRow = ({ player }) => (
   <Table.Row
     className="gm_clickable"
-    onClick={() => navigate(`/tools?player=${player.charname}`)}
+    onClick={() => navigate(`/tools/player/${player.charname}`)}
   >
     <Table.Cell>
       <Image

--- a/client/src/components/tools/item/ah.jsx
+++ b/client/src/components/tools/item/ah.jsx
@@ -9,7 +9,7 @@ export default ({ name, stack }) => {
 
   const fetchAh = () => {
     apiUtil.get(
-      { url: `api/v1/items/${name}/ah?stack=${stack}` },
+      { url: `/api/v1/items/${name}/ah?stack=${stack}` },
       async (error, res) => {
         try {
           if (!error && res.status === 200) {
@@ -63,12 +63,12 @@ export default ({ name, stack }) => {
             <Table.Row key={`ah_history_${i}`}>
               <Table.Cell>{`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}</Table.Cell>
               <Table.Cell>
-                <Link to={`/tools?player=${history.seller_name}`}>
+                <Link to={`/tools/player/${history.seller_name}`}>
                   {history.seller_name}
                 </Link>
               </Table.Cell>
               <Table.Cell>
-                <Link to={`/tools?player=${history.buyer_name}`}>
+                <Link to={`/tools/player/${history.buyer_name}`}>
                   {history.buyer_name}
                 </Link>
               </Table.Cell>

--- a/client/src/components/tools/item/bazaar.jsx
+++ b/client/src/components/tools/item/bazaar.jsx
@@ -9,7 +9,7 @@ export default ({ name }) => {
 
   const fetchBazaar = () => {
     setBazaar(null);
-    apiUtil.get({ url: `api/v1/items/${name}/bazaar` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/items/${name}/bazaar` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setBazaar(await res.json());
@@ -49,7 +49,7 @@ export default ({ name }) => {
         {bazaar.map((sell, i) => (
           <Table.Row key={`ah_history_${i}`}>
             <Table.Cell>
-              <Link to={`/tools?player=${sell.charname}`}>{sell.charname}</Link>
+              <Link to={`/tools/player/${sell.charname}`}>{sell.charname}</Link>
             </Table.Cell>
             <Table.Cell>{`${sell.bazaar.toLocaleString()}g`}</Table.Cell>
           </Table.Row>

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -69,7 +69,7 @@ const Crafting = ({ name }) => {
 
   const fetchCrafts = () => {
     setCrafts(null);
-    apiUtil.get({ url: `api/v1/items/${name}/crafts` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/items/${name}/crafts` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setCrafts(await res.json());

--- a/client/src/components/tools/itemsearch.jsx
+++ b/client/src/components/tools/itemsearch.jsx
@@ -63,6 +63,7 @@ const Itemsearch = ({ history }) => {
         setInitial(false);
         setTotal(0);
         setResults([]);
+        setLastSearch(null);
       } else if (searchParam !== lastSearch) {
         // Search if the current search param isn't the last searched
         fetchItems({ search: searchParam, limit: 10, offset: 0 });

--- a/client/src/components/tools/player.jsx
+++ b/client/src/components/tools/player.jsx
@@ -1,13 +1,13 @@
+import { navigate } from '@reach/router';
 import React from 'react';
-import { Segment, Icon, Image, Header } from 'semantic-ui-react';
-
-import Jobs from './player/jobs';
-import Equipment from './player/equipment';
-import Crafts from './player/crafts';
-import Sales from './player/sales';
+import { Header, Icon, Image, Segment, Loader } from 'semantic-ui-react';
+import apiUtil from '../../apiUtil';
 import images from '../../images';
-
+import Crafts from './player/crafts';
+import Equipment from './player/equipment';
+import Jobs from './player/jobs';
 import './player/playerStyles.css';
+import Sales from './player/sales';
 
 const Linkshell = ({ ls }) => {
   if (!ls || !ls.itemid) {
@@ -22,8 +22,41 @@ const Linkshell = ({ ls }) => {
   );
 };
 
-export default ({ player }) => {
+export default ({ charname, setLoading, setSearch }) => {
+  const [player, setPlayer] = React.useState(null);
   const [equip, setEquip] = React.useState(null);
+
+  const fetchPlayer = player => {
+    if (!player) return;
+
+    setLoading(true);
+    apiUtil.get(
+      {
+        url: `/api/v1/chars/${player}`,
+        json: true,
+      },
+      (error, data) => {
+        setPlayer(data);
+        setSearch(data.name);
+        setLoading(false);
+      }
+    );
+  };
+
+  const fetchMemoizedPlayer = React.useCallback(fetchPlayer);
+
+  React.useEffect(() => {
+    if (charname) fetchMemoizedPlayer(charname);
+  }, [charname]);
+
+  if (!player) {
+    return (
+      <Segment>
+        <Loader inline style={{ width: '100%' }} />
+      </Segment>
+    );
+  }
+
   return (
     <Segment>
       <Header>

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -5,7 +5,7 @@ import apiUtil from '../../../apiUtil';
 
 const formatItem = itemname => {
   return (
-    <Link to={`/tools?item=${encodeURIComponent(itemname)}`}>
+    <Link to={`/tools/item/${encodeURIComponent(itemname)}`}>
       {itemname
         .split('_')
         .map(string => {
@@ -22,7 +22,7 @@ const formatItem = itemname => {
 const formatPlayerLink = (player, target) => {
   if (player === target) return player;
 
-  return <Link to={`/tools?player=${target}`}>{target}</Link>;
+  return <Link to={`/tools/player/${target}`}>{target}</Link>;
 };
 
 export default ({ name }) => {
@@ -31,7 +31,7 @@ export default ({ name }) => {
 
   const fetchAh = () => {
     setAh(null);
-    apiUtil.get({ url: `api/v1/chars/${name}/ah` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/chars/${name}/ah` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setAh(await res.json());

--- a/client/src/components/tools/player/bazaar.jsx
+++ b/client/src/components/tools/player/bazaar.jsx
@@ -5,7 +5,7 @@ import apiUtil from '../../../apiUtil';
 
 const formatItem = itemname => {
   return (
-    <Link to={`/tools?item=${encodeURIComponent(itemname)}`}>
+    <Link to={`/tools/item/${encodeURIComponent(itemname)}`}>
       {itemname
         .split('_')
         .map(string => {
@@ -25,7 +25,7 @@ export default ({ name }) => {
 
   const fetchBazaar = () => {
     setBazaar(null);
-    apiUtil.get({ url: `api/v1/chars/${name}/bazaar` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/chars/${name}/bazaar` }, async (error, res) => {
       if (res.status === 200) {
         setBazaar(await res.json());
         setError(false);

--- a/client/src/components/tools/player/crafts.jsx
+++ b/client/src/components/tools/player/crafts.jsx
@@ -8,7 +8,7 @@ export default ({ name }) => {
 
   const fetchCrafts = () => {
     setCrafts(null);
-    apiUtil.get({ url: `api/v1/chars/${name}/crafts` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/chars/${name}/crafts` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setCrafts(await res.json());

--- a/client/src/components/tools/player/equipment.jsx
+++ b/client/src/components/tools/player/equipment.jsx
@@ -12,7 +12,7 @@ const emptySlot = slotid => (
 
 const itemSlot = equip => (
   <div title={equip.name} className="equipslot">
-    <Link to={`/tools?item=${encodeURIComponent(equip.name)}`}>
+    <Link to={`/tools/item/${encodeURIComponent(equip.name)}`}>
       <img
         alt={`eq${equip.equipslotid}`}
         src={images.item(equip.itemid)}
@@ -28,7 +28,7 @@ export default ({ name, job, ranks, callback }) => {
 
   const fetchEquip = () => {
     setEquip(null);
-    apiUtil.get({ url: `api/v1/chars/${name}/equip` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/chars/${name}/equip` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           const data = await res.json();

--- a/client/src/components/tools/playersearch.jsx
+++ b/client/src/components/tools/playersearch.jsx
@@ -64,6 +64,7 @@ const Playersearch = ({ history }) => {
         setInitial(false);
         setTotal(0);
         setResults([]);
+        setLastSearch(null);
       } else if (searchParam !== lastSearch) {
         // Search if the current search param isn't the last searched
         fetchPlayers({ search: searchParam, limit: 10, offset: 0 });


### PR DESCRIPTION
Rework of the tools pages to improve navigation within it, such that the URL follows the state of the tools page more precisely. This is accomplished by using the router to perform the navigation instead of doing it via React state changes.

Examples of URLs with this PR:
* `/tools/online` will navigate to the `Who's Online` tab.
* `/tools/item` will navigate to the `Item Search` tab.
* `/tools/item?search=goblin` will navigate to the `Item Search` tab, and perform a search with the given param.
* `/tools/item/goblin_helm` will navigate to the `Item Search` tab and show the Goblin Helm page.

Back and forth navigation now also works within the tools page, since bigger state changes are now reflected as an URL change.

Pagination will need some work, if we want better navigation for when that is used, since that is still all state-based at the moment.