### PR TITLE
Fix prop type warnings

### DIFF
--- a/client/src/components/page.jsx
+++ b/client/src/components/page.jsx
@@ -33,6 +33,11 @@ const Page = props => {
   );
 };
 
+const ListWithUpdated = PropTypes.shape({
+  updated: PropTypes.string.isRequired,
+  list: PropTypes.arrayOf(PropTypes.string),
+});
+
 Page.propTypes = {
   config: PropTypes.shape({
     install: PropTypes.shape({
@@ -58,12 +63,12 @@ Page.propTypes = {
       })
     ),
     rules: PropTypes.shape({
-      allowed: PropTypes.arrayOf(PropTypes.string),
-      disallowed: PropTypes.arrayOf(PropTypes.string),
-      discord: PropTypes.arrayOf(PropTypes.string),
-      rules: PropTypes.arrayOf(PropTypes.string),
-      terms: PropTypes.arrayOf(PropTypes.string),
-      yells: PropTypes.arrayOf(PropTypes.string),
+      allowed: ListWithUpdated,
+      disallowed: ListWithUpdated,
+      discord: ListWithUpdated,
+      rules: ListWithUpdated,
+      terms: ListWithUpdated,
+      yells: ListWithUpdated,
     }),
   }).isRequired,
 };

--- a/client/src/components/rules.jsx
+++ b/client/src/components/rules.jsx
@@ -204,26 +204,29 @@ const Rules = ({ list }) => {
   );
 };
 
+const ListWithUpdated = PropTypes.shape({
+  updated: PropTypes.string.isRequired,
+  list: PropTypes.arrayOf(PropTypes.string),
+});
+
 Rules.propTypes = {
   list: PropTypes.shape({
-    allowed: PropTypes.arrayOf(PropTypes.string),
-    disallowed: PropTypes.arrayOf(PropTypes.string),
-    discord: PropTypes.arrayOf(PropTypes.string),
-    rules: PropTypes.arrayOf(PropTypes.string),
-    terms: PropTypes.arrayOf(PropTypes.string),
-    yells: PropTypes.arrayOf(PropTypes.string),
-  }),
+    allowed: ListWithUpdated,
+    disallowed: ListWithUpdated,
+    discord: ListWithUpdated,
+    rules: ListWithUpdated,
+    terms: ListWithUpdated,
+    yells: ListWithUpdated,
+  }).isRequired,
 };
 
 Rules.defaultProps = {
-  list: {
-    allowed: [],
-    disallowed: [],
-    discord: [],
-    rules: [],
-    terms: [],
-    yells: [],
-  },
+  allowed: {},
+  disallowed: {},
+  discord: {},
+  rules: {},
+  terms: {},
+  yells: {},
 };
 
 export default Rules;


### PR DESCRIPTION
Fix for the following prop type warnings, since the config structure was changed a bit.
```
Warning: Failed prop type: Invalid prop `config.rules.discord` of type `object` supplied to `Page`, expected an array.
    in Page (at App.jsx:121)
    in App (at src/index.js:7)
console.<computed> @ index.js:1

Warning: Failed prop type: Invalid prop `list.discord` of type `object` supplied to `Rules`, expected an array.
    in Rules (at page.jsx:26)
    in Page (at App.jsx:121)
    in div (at App.jsx:112)
    in div (at App.jsx:110)
    in App (at src/index.js:7)
```