### PR TITLE
Fixes #78 - Make tabs responsive on tools

### DIFF
--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { createHistory, Link, Router, useMatch } from '@reach/router';
+import { Nav } from 'react-bootstrap';
 import Accounts from './accounts';
 import Itemsearch from './tools/itemsearch';
 import Playersearch from './tools/playersearch';
 import OnlineList from './tools/OnlineList';
 import YellTab from './tools/YellTab';
-import { Nav } from 'react-bootstrap';
 
 const TabItem = ({ to, activeTab, disabled = false, children }) => {
-  console.log(to);
-  console.log(activeTab);
   return (
     <Nav.Item>
       <Nav.Link
@@ -29,37 +27,39 @@ const Tools = () => {
   const activeTab = useMatch(':tab/*')?.tab || 'online';
 
   return (
-    <div className="gm_tools">
-      <div className="gm_tools-content bg-light py-3">
-        <Nav fill variant="tabs" className="mb-3">
-          <TabItem to="account" activeTab={activeTab} eventKey="1">
-            User Management
-          </TabItem>
+    <div className="bg-light">
+      <Nav fill variant="tabs">
+        <TabItem to="account" activeTab={activeTab} eventKey="1">
+          User Management
+        </TabItem>
 
-          <TabItem to="online" activeTab={activeTab} eventKey="2">
-            Who's Online
-          </TabItem>
+        <TabItem to="online" activeTab={activeTab} eventKey="2">
+          Who&apos;s Online
+        </TabItem>
 
-          <TabItem to="item" activeTab={activeTab} eventKey="3">
-            Item Search
-          </TabItem>
+        <TabItem to="item" activeTab={activeTab} eventKey="3">
+          Item Search
+        </TabItem>
 
-          <TabItem to="player" activeTab={activeTab} eventKey="4">
-            Player Search
-          </TabItem>
+        <TabItem to="player" activeTab={activeTab} eventKey="4">
+          Player Search
+        </TabItem>
 
-          <TabItem to="yells" activeTab={activeTab} eventKey="5">
-            Yells
-          </TabItem>
-        </Nav>
-        <Router>
-          <OnlineList path="/" />
-          <OnlineList path="online" />
-          {/* <Accounts path="account" /> */}
-          <Itemsearch path="item/*" history={history} />
-          <Playersearch path="player/*" history={history} />
-          <YellTab path="yells" />
-        </Router>
+        <TabItem to="yells" activeTab={activeTab} eventKey="5">
+          Yells
+        </TabItem>
+      </Nav>
+      <div className="gm_tools">
+        <div className="gm_tools-content bg-light my-3">
+          <Router>
+            <OnlineList path="/" />
+            <OnlineList path="online" />
+            {/* <Accounts path="account" /> */}
+            <Itemsearch path="item/*" history={history} />
+            <Playersearch path="player/*" history={history} />
+            <YellTab path="yells" />
+          </Router>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -7,16 +7,22 @@ import OnlineList from './tools/OnlineList';
 import YellTab from './tools/YellTab';
 import { Nav } from 'react-bootstrap';
 
-const TabItem = ({ to, activeTab, disabled = false, children }) => (
-  <Menu.Item
-    as={disabled ? undefined : Link}
-    to={disabled ? undefined : to}
-    active={to === activeTab}
-    disabled={disabled}
-  >
-    {children}
-  </Menu.Item>
-);
+const TabItem = ({ to, activeTab, disabled = false, children }) => {
+  console.log(to);
+  console.log(activeTab);
+  return (
+    <Nav.Item>
+      <Nav.Link
+        as={disabled ? undefined : Link}
+        to={disabled ? undefined : to}
+        active={to === activeTab}
+        disabled={disabled}
+      >
+        {children}
+      </Nav.Link>
+    </Nav.Item>
+  );
+};
 
 const Tools = () => {
   const history = createHistory(window);
@@ -25,61 +31,26 @@ const Tools = () => {
   return (
     <div className="gm_tools">
       <div className="gm_tools-content bg-light py-3">
-        <Nav fill variant="tabs">
-          <Nav.Item>
-            <Nav.Link
-              to="account"
-              disabled
-              active={selected === 'account'}
-              onClick={updateTab('account')}
-              eventKey="1"
-            >
-              User Management
-            </Nav.Link>
-          </Nav.Item>
+        <Nav fill variant="tabs" className="mb-3">
+          <TabItem to="account" activeTab={activeTab} eventKey="1">
+            User Management
+          </TabItem>
 
-          <Nav.Item>
-            <Nav.Link
-              to="online"
-              active={selected === 'online'}
-              onClick={updateTab('online')}
-              eventKey="2"
-            >
-              Who's Online
-            </Nav.Link>
-          </Nav.Item>
-          <Nav.Item>
-            <Nav.Link
-              to="item"
-              active={selected === 'items'}
-              onClick={updateTab('items')}
-              eventKey="3"
-            >
-              Item Search
-            </Nav.Link>
-          </Nav.Item>
+          <TabItem to="online" activeTab={activeTab} eventKey="2">
+            Who's Online
+          </TabItem>
 
-          <Nav.Item>
-            <Nav.Link
-              to="player"
-              active={selected === 'chars'}
-              onClick={updateTab('chars')}
-              eventKey="4"
-            >
-              Player Search
-            </Nav.Link>
-          </Nav.Item>
+          <TabItem to="item" activeTab={activeTab} eventKey="3">
+            Item Search
+          </TabItem>
 
-          <Nav.Item>
-            <Nav.Link
-              to="yells"
-              active={selected === 'yells'}
-              onClick={updateTab('yells')}
-              eventKey="5"
-            >
-              Yells
-            </Nav.Link>
-          </Nav.Item>
+          <TabItem to="player" activeTab={activeTab} eventKey="4">
+            Player Search
+          </TabItem>
+
+          <TabItem to="yells" activeTab={activeTab} eventKey="5">
+            Yells
+          </TabItem>
         </Nav>
         <Router>
           <OnlineList path="/" />

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Menu } from 'semantic-ui-react';
-
 import { createHistory, navigate } from '@reach/router';
 import Accounts from './accounts';
 import Itemsearch from './tools/itemsearch';
 import Playersearch from './tools/playersearch';
 import OnlineList from './tools/OnlineList';
 import YellTab from './tools/YellTab';
+import { Nav } from 'react-bootstrap';
 
 const Tools = () => {
   const history = createHistory(window);
@@ -30,31 +29,58 @@ const Tools = () => {
 
   return (
     <div className="gm_tools">
-      <div className="gm_tools-content">
-        <Menu pointing>
-          <Menu.Item
-            disabled
-            active={selected === 'account'}
-            onClick={updateTab('account')}
-          >
-            User Management
-          </Menu.Item>
-          <Menu.Item
-            active={selected === 'online'}
-            onClick={updateTab('online')}
-          >
-            Who's Online
-          </Menu.Item>
-          <Menu.Item active={selected === 'items'} onClick={updateTab('items')}>
-            Item Search
-          </Menu.Item>
-          <Menu.Item active={selected === 'chars'} onClick={updateTab('chars')}>
-            Player Search
-          </Menu.Item>
-          <Menu.Item active={selected === 'yells'} onClick={updateTab('yells')}>
-            Yells
-          </Menu.Item>
-        </Menu>
+      <div className="gm_tools-content bg-light py-3">
+        <Nav fill variant="tabs">
+          <Nav.Item>
+            <Nav.Link
+              disabled
+              active={selected === 'account'}
+              onClick={updateTab('account')}
+              eventKey="1"
+            >
+              User Management
+            </Nav.Link>
+          </Nav.Item>
+
+          <Nav.Item>
+            <Nav.Link
+              active={selected === 'online'}
+              onClick={updateTab('online')}
+              eventKey="2"
+            >
+              Who's Online
+            </Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link
+              active={selected === 'items'}
+              onClick={updateTab('items')}
+              eventKey="3"
+            >
+              Item Search
+            </Nav.Link>
+          </Nav.Item>
+
+          <Nav.Item>
+            <Nav.Link
+              active={selected === 'chars'}
+              onClick={updateTab('chars')}
+              eventKey="4"
+            >
+              Player Search
+            </Nav.Link>
+          </Nav.Item>
+
+          <Nav.Item>
+            <Nav.Link
+              active={selected === 'yells'}
+              onClick={updateTab('yells')}
+              eventKey="5"
+            >
+              Yells
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
         {/* {selected === 'account' && <Accounts />} */}
         {selected === 'online' && <OnlineList />}
         {(item || selected === 'items') && (

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -26,6 +26,10 @@
 
 $body-bg: #e6e6e6;
 
+$theme-colors: (
+  'primary': #120d37,
+);
+
 // Import Bootstrap
 // - This import must go below all SASS variable overrides
 @import 'node_modules/bootstrap/scss/bootstrap';

--- a/client/src/index.scss
+++ b/client/src/index.scss
@@ -33,3 +33,10 @@ $theme-colors: (
 // Import Bootstrap
 // - This import must go below all SASS variable overrides
 @import 'node_modules/bootstrap/scss/bootstrap';
+
+// CSS overrides
+// - This must got below the Bootstrap import
+
+.nav-tabs .nav-link {
+  border: 1px solid #e6e6e6;
+}


### PR DESCRIPTION
- Changed tabs on Tools so they are responsive. Admittedly not as pretty as Semantic UI's menu tabs but they were breaking the layout on mobile view.
- Set Bootstrap theme primary colour to dark purple (same as yell box), so that the nav links are not bright blue.

The primary theme colour is a one-liner which can be changed easily if required. I did try a dark red to go with the Eden apple theme, but it looked a bit out of place with the current colour scheme.

(Note that the primary colour affects all link text and primary buttons, so a readable colour must be used.)