### PR TITLE
Add class to make Semantic-UI Menu responsive (fixes #78)

### DIFF
--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -271,3 +271,9 @@ p.gm_lineseperate {
   flex-direction: row;
   flex-wrap: wrap;
 }
+
+.ui.menu.wrapped .item {
+  flex-grow: 1;
+  text-align: center;
+  display: block;
+}

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -265,3 +265,9 @@ p.gm_lineseperate {
     margin: 10px 0;
   }
 }
+
+.wrapped {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -26,8 +26,8 @@ const Tools = () => {
   return (
     <div className="gm_tools">
       <div className="gm_tools-content">
-        <Menu pointing>
-          <TabItem to="account" disabled={true} activeTab={activeTab}>
+        <Menu pointing className="wrapped">
+          <TabItem to="account" disabled activeTab={activeTab}>
             User Management
           </TabItem>
           <TabItem to="online" activeTab={activeTab}>


### PR DESCRIPTION
An alternate resolution to https://github.com/EdenServer/eden-web/pull/79 regarding the responsiveness issues caused by the Semantic UI Menu styles.

Here I've simply added a class to the Menu, which makes the tabs wrap onto multiple lines when they run out of space on the screen, rather than break outside of the page container.

I think this looks better for what it's worth, even if the lack of built-in responsiveness irks me. :p