### PR TITLE
Limit Character Searches to Normal Status

### DIFF
--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -314,7 +314,8 @@ const fetchChars = async (
             JOIN char_look ON chars.charid = char_look.charid
             JOIN char_jobs ON chars.charid = char_jobs.charid
             LEFT JOIN accounts_sessions on chars.charid = accounts_sessions.charid
-            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ?
+            LEFT JOIN accounts ON chars.accid = accounts.id
+            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5
             HAVING isOnline IN (1,?) ORDER BY chars.charname ASC LIMIT ? OFFSET ?;`;
     const results = await query(statement, [
       `${search}%`,

--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -315,7 +315,7 @@ const fetchChars = async (
             JOIN char_jobs ON chars.charid = char_jobs.charid
             LEFT JOIN accounts_sessions on chars.charid = accounts_sessions.charid
             LEFT JOIN accounts ON chars.accid = accounts.id
-            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5
+            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status = 1
             HAVING isOnline IN (1,?) ORDER BY chars.charname ASC LIMIT ? OFFSET ?;`;
     const results = await query(statement, [
       `${search}%`,

--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -306,7 +306,7 @@ const fetchChars = async (
 ) => {
   try {
     const total = await query(
-      `SELECT COUNT(*) AS ct FROM chars WHERE gmlevel = 0 AND charname LIKE ?;`,
+      `SELECT COUNT(*) AS ct FROM chars WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5;`,
       [`${search}%`]
     );
     const statement = `SELECT *, chars.charid AS charid, chars.accid AS accid, IF(accounts_sessions.charid IS NULL, 0, 1) AS isOnline FROM chars

--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -315,7 +315,7 @@ const fetchChars = async (
             JOIN char_jobs ON chars.charid = char_jobs.charid
             LEFT JOIN accounts_sessions on chars.charid = accounts_sessions.charid
             LEFT JOIN accounts ON chars.accid = accounts.id
-            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status = 1
+            WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5
             HAVING isOnline IN (1,?) ORDER BY chars.charname ASC LIMIT ? OFFSET ?;`;
     const results = await query(statement, [
       `${search}%`,

--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -306,7 +306,9 @@ const fetchChars = async (
 ) => {
   try {
     const total = await query(
-      `SELECT COUNT(*) AS ct FROM chars WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5;`,
+      `SELECT COUNT(*) AS ct FROM chars
+      LEFT JOIN accounts ON chars.accid = accounts.id
+      WHERE chars.deleted IS NULL AND gmlevel = 0 AND charname LIKE ? AND status < 5;`,
       [`${search}%`]
     );
     const statement = `SELECT *, chars.charid AS charid, chars.accid AS accid, IF(accounts_sessions.charid IS NULL, 0, 1) AS isOnline FROM chars


### PR DESCRIPTION
New character status hidden (5).  This was necessary to hide a vulgar representation of an existing player's character name.  Perhaps a better alternative is to omit banned, suspended, and inactive accounts from the search.  If so, status = 1 will do that. 