### PR TITLE
Use colored brackets for auto-translate in yells

### DIFF
--- a/client/src/components/YellText.tsx
+++ b/client/src/components/YellText.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+interface YellTextProps {
+  date: Date;
+  speaker: string;
+  message: string;
+}
+
+const translatePattern = /«([^»]+?)»/g;
+
+function parseYell(message: string) {
+  let currentIdx = 0;
+  let result = [];
+  for (const match of message.matchAll(translatePattern)) {
+    let translatedText = match[1];
+    result.push(message.slice(currentIdx, match.index));
+
+    result.push(<span className="gm_autotranslate-start">{'{'}</span>);
+    result.push(translatedText);
+    result.push(<span className="gm_autotranslate-end">{'}'}</span>);
+
+    currentIdx = match.index! + translatedText.length + 2;
+  }
+
+  if (currentIdx < message.length) {
+    result.push(message.slice(currentIdx));
+  }
+  return result;
+}
+
+const YellText = (yell: YellTextProps) => (
+  <>
+    <span className="gm_yell-name">
+      [{new Date(yell.date).toLocaleTimeString()}] {yell.speaker}
+    </span>{' '}
+    : &nbsp;
+    <span className="gm_yell-text">{parseYell(yell.message)}</span>
+  </>
+);
+
+export default YellText;

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -108,6 +108,16 @@ body {
   color: white;
 }
 
+.gm_autotranslate-start {
+  color: lightgreen;
+  font-weight: bold;
+}
+
+.gm_autotranslate-end {
+  color: red;
+  font-weight: bold;
+}
+
 /* Tools */
 
 .gm_tools {

--- a/client/src/components/yellbox.jsx
+++ b/client/src/components/yellbox.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import apiUtil from '../apiUtil';
+import YellText from './YellText';
 
 class Yells extends React.PureComponent {
   constructor(props) {
@@ -30,11 +31,7 @@ class Yells extends React.PureComponent {
       <ul className="gm_yell-container h-100 rounded">
         {yells.map((yell, i) => (
           <li key={`yell_${i}`} className="gm_yell-message">
-            <span className="gm_yell-name">
-              [{new Date(yell.date).toLocaleTimeString()}] {yell.speaker}
-            </span>{' '}
-            : &nbsp;
-            <span className="gm_yell-text">{yell.message}</span>
+            <YellText {...yell} />
           </li>
         ))}
       </ul>

--- a/client/src/react-app-env.d.ts
+++ b/client/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "downlevelIteration": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
Changes the current auto-translate indicators to be colored brackets instead.

![image](https://user-images.githubusercontent.com/774909/85291340-aab25a80-b49a-11ea-91a3-a3fe4bc7b4c1.png)
