### PR TITLE
Show static search param instead of current search input state for no result message

### DIFF
--- a/client/src/components/tools/itemsearch.jsx
+++ b/client/src/components/tools/itemsearch.jsx
@@ -109,7 +109,7 @@ const Itemsearch = ({ history }) => {
       {!itemname && results.length === 0 && (
         <Segment>
           {initial
-            ? `No results for "${search}".`
+            ? `No results for "${searchParam}".`
             : 'Begin searching an item by typing in the search box above.'}
         </Segment>
       )}

--- a/client/src/components/tools/playersearch.jsx
+++ b/client/src/components/tools/playersearch.jsx
@@ -119,7 +119,7 @@ const Playersearch = ({ history }) => {
       {!charname && results.length === 0 && (
         <Segment>
           {initial
-            ? `No results for "${search}".`
+            ? `No results for "${searchParam}".`
             : 'Begin searching for a player by typing in the search box above.'}
         </Segment>
       )}


### PR DESCRIPTION
Current the `No result for "xyz"` shows the current search input state, which means that it changes when the input is changed.
This PR changes it to show the search query parameter instead, which is static until the URL changes.