### PR TITLE
Bug/item detail without desc

### DIFF
--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -177,17 +177,13 @@ export default ({ history, itemname, setLoading }) => {
             </Button>
           )}
         </div>
-        {item.desc !== null && typeof item.desc !== 'undefined' &&
-          <div className="eden_item-description">
-            {item.desc.split('\n').map((s, i) => (
-              <p key={`desc_ln_${i}`}>
-                {descriptionWithElements(s, i)}
-                <br />
-              </p>
-            ))}
-            {item.armor && <p>{item.armor}</p>}
-          </div>
-        }
+        <div className="eden_item-description">
+          {item.desc !== null && typeof item.desc !== 'undefined' && item.desc.split('\n').map((s, i) => (<p key={`desc_ln_${i}`}> {descriptionWithElements(s, i)}
+            <br />
+          </p>
+          ))}
+          {item.armor && <p>{item.armor}</p>}
+        </div>
       </Header>
       <Accordion fluid styled>
         <Accordion.Title active={ah} onClick={() => setAh(!ah)}>

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -177,15 +177,17 @@ export default ({ history, itemname, setLoading }) => {
             </Button>
           )}
         </div>
-        <div className="eden_item-description">
-          {item.desc.split('\n').map((s, i) => (
-            <p key={`desc_ln_${i}`}>
-              {descriptionWithElements(s, i)}
-              <br />
-            </p>
-          ))}
-          {item.armor && <p>{item.armor}</p>}
-        </div>
+        {item.desc !== null && typeof item.desc !== 'undefined' &&
+          <div className="eden_item-description">
+            {item.desc.split('\n').map((s, i) => (
+              <p key={`desc_ln_${i}`}>
+                {descriptionWithElements(s, i)}
+                <br />
+              </p>
+            ))}
+            {item.armor && <p>{item.armor}</p>}
+          </div>
+        }
       </Header>
       <Accordion fluid styled>
         <Accordion.Title active={ah} onClick={() => setAh(!ah)}>

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -178,11 +178,9 @@ export default ({ history, itemname, setLoading }) => {
           )}
         </div>
         <div className="eden_item-description">
-          {item.desc !== null &&
-            typeof item.desc !== 'undefined' &&
+          {item.desc &&
             item.desc.split('\n').map((s, i) => (
               <p key={`desc_ln_${i}`}>
-                {' '}
                 {descriptionWithElements(s, i)}
                 <br />
               </p>

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -178,10 +178,15 @@ export default ({ history, itemname, setLoading }) => {
           )}
         </div>
         <div className="eden_item-description">
-          {item.desc !== null && typeof item.desc !== 'undefined' && item.desc.split('\n').map((s, i) => (<p key={`desc_ln_${i}`}> {descriptionWithElements(s, i)}
-            <br />
-          </p>
-          ))}
+          {item.desc !== null &&
+            typeof item.desc !== 'undefined' &&
+            item.desc.split('\n').map((s, i) => (
+              <p key={`desc_ln_${i}`}>
+                {' '}
+                {descriptionWithElements(s, i)}
+                <br />
+              </p>
+            ))}
           {item.armor && <p>{item.armor}</p>}
         </div>
       </Header>


### PR DESCRIPTION
If an armor has no description, the item detail page would error (i.e. http://edenxi.com/tools/item/rusty_subligar)

I simply added a null/undefined check to the item.desc property before the split call