### PR TITLE
Show stack size in player auction history when a stack is purchased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 build
 .env
-
+.idea
 sql/queries/*
 !sql/queries/samples
 !sql/queries/README.md

--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -131,7 +131,8 @@ const getCharCrafts = async (query, charid) => {
 
 const getCharAH = async (query, charname, limit = 10) => {
   try {
-    const statement = `SELECT name, seller_name, buyer_name, sale, sell_date FROM server_auctionhouse
+    const statement = `SELECT name, CASE WHEN stack = 1 THEN stacksize ELSE 1 END AS stack_size,
+                              seller_name, buyer_name, sale, sell_date FROM server_auctionhouse
             JOIN item_basic on item_basic.itemid = server_auctionhouse.itemid
             WHERE sell_date != 0 AND (seller_name = ? OR buyer_name = ?) ORDER BY sell_date DESC LIMIT ?;`;
     return await query(statement, [charname, charname, limit]);

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -14,7 +14,7 @@ const formatItem = (itemname, stacksize) => {
             string.length
           )}`;
         })
-        .join(' ') + (stacksize === '1' ? '' : " x" + stacksize)}
+        .join(' ') + (stacksize === '1' ? '' : ' x' + stacksize)}
     </Link>
   );
 };
@@ -76,7 +76,9 @@ export default ({ name }) => {
           return (
             <Table.Row key={`ah_history_${i}`}>
               <Table.Cell>{`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}</Table.Cell>
-              <Table.Cell>{formatItem(history.name, history.stack_size)}</Table.Cell>
+              <Table.Cell>
+                {formatItem(history.name, history.stack_size)}
+              </Table.Cell>
               <Table.Cell>
                 {formatPlayerLink(name, history.seller_name)}
               </Table.Cell>

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -3,7 +3,7 @@ import { Table, Loader } from 'semantic-ui-react';
 import { Link } from '@reach/router';
 import apiUtil from '../../../apiUtil';
 
-const formatItem = itemname => {
+const formatItem = (itemname, stacksize) => {
   return (
     <Link to={`/tools/item/${encodeURIComponent(itemname)}`}>
       {itemname
@@ -14,7 +14,7 @@ const formatItem = itemname => {
             string.length
           )}`;
         })
-        .join(' ')}
+        .join(' ') + (stacksize === '1' ? '' : " x" + stacksize)}
     </Link>
   );
 };
@@ -76,7 +76,7 @@ export default ({ name }) => {
           return (
             <Table.Row key={`ah_history_${i}`}>
               <Table.Cell>{`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}</Table.Cell>
-              <Table.Cell>{formatItem(history.name)}</Table.Cell>
+              <Table.Cell>{formatItem(history.name, history.stack_size)}</Table.Cell>
               <Table.Cell>
                 {formatPlayerLink(name, history.seller_name)}
               </Table.Cell>

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -5,7 +5,12 @@ import apiUtil from '../../../apiUtil';
 
 const formatItem = (itemname, stacksize) => {
   return (
-    <Link to={`/tools/item/${encodeURIComponent(itemname)}`}>
+    <Link
+      to={
+        `/tools/item/${encodeURIComponent(itemname)}` +
+        (stacksize > 1 ? `?stack=true` : ``)
+      }
+    >
       {itemname
         .split('_')
         .map(string => {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9592857/89737963-1b113d00-da43-11ea-84cb-01e5f5c226ed.png)


Displays "x{stacksize}" next to purchases of a stack of items in player auction history. 

Resolves https://github.com/EdenServer/eden-web/issues/6