### PR TITLE
Correct AH listings showing "x1" for single item purchasing

### DIFF
--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -8,7 +8,7 @@ const formatItem = (itemname, stacksize) => {
     <Link
       to={
         `/tools/item/${encodeURIComponent(itemname)}` +
-        (stacksize > 1 ? `?stack=true` : ``)
+        (parseInt(stacksize) > 1 ? `?stack=true` : ``)
       }
     >
       {itemname
@@ -19,7 +19,7 @@ const formatItem = (itemname, stacksize) => {
             string.length
           )}`;
         })
-        .join(' ') + (parseInt(stacksize) === 1 ? '' : ' x' + stacksize)}
+        .join(' ') + (parseInt(stacksize) > 1 ? ` x${stacksize}` : '')}
     </Link>
   );
 };

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -19,7 +19,7 @@ const formatItem = (itemname, stacksize) => {
             string.length
           )}`;
         })
-        .join(' ') + (stacksize === '1' ? '' : ' x' + stacksize)}
+        .join(' ') + (parseInt(stacksize) === 1 ? '' : ' x' + stacksize)}
     </Link>
   );
 };


### PR DESCRIPTION
My assumption is that this is a difference in versioning between my local deployment and the production servers, but the current AH listing page displays "x1" for single units.