### PR TITLE
fix navbar shrink on safari and safari mobile

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -106,28 +106,26 @@ class App extends Component {
     ];
 
     return (
-      <>
-        <div className="gm_main h-100">
-          <SiteNavbar links={links} />
-          <div className="gm_content my-3">
-            {config && Object.keys(config).length === 0 && (
-              <div className="alert alert-warning m-0 text-center">
-                <span>
-                  Website tools are currently down. Please check again later.
-                </span>
-              </div>
-            )}
-            {ready && (
-              <LandingPage
-                config={config}
-                apiNoResponse={apiNoResponse}
-                className="h-100"
-              />
-            )}
+      <div className="gm_main h-100">
+        <SiteNavbar links={links} />
+        {config && Object.keys(config).length === 0 && (
+          <div className="alert alert-warning m-0 text-center">
+            <span>
+              Website tools are currently down. Please check again later.
+            </span>
           </div>
-          <SiteFooter className="mt-5" />
+        )}
+        <div className="gm_content my-3">
+          {ready && (
+            <LandingPage
+              config={config}
+              apiNoResponse={apiNoResponse}
+              className="h-100"
+            />
+          )}
         </div>
-      </>
+        <SiteFooter className="mt-5" />
+      </div>
     );
   }
 }

--- a/client/src/components/SiteFooter/SiteFooter.jsx
+++ b/client/src/components/SiteFooter/SiteFooter.jsx
@@ -14,16 +14,11 @@ const SiteFooter = () => {
           <p className="text-light">
             <small>
               All FINAL FANTASY&reg; XI content and images &copy; 2002-
-              {new Date().getFullYear()}{' '}
-              <a href="https://www.square-enix.com/" className="text-white">
-                SQUARE ENIX
-              </a>{' '}
-              CO., LTD. All Rights Reserved. <br /> FINAL FANTASY&reg; is a
-              registered trademark of{' '}
-              <a href="https://www.square-enix.com/" className="text-white">
-                SQUARE ENIX
-              </a>{' '}
-              CO., LTD. All Rights Reserved.
+              {new Date().getFullYear()}
+              SQUARE ENIX CO., LTD. All Rights Reserved.
+              <br />
+              FINAL FANTASY&reg; is a registered trademark of SQUARE ENIX CO.,
+              LTD. All Rights Reserved.
             </small>
           </p>
         </Col>

--- a/client/src/components/SiteNavbar/SiteNavbar.jsx
+++ b/client/src/components/SiteNavbar/SiteNavbar.jsx
@@ -7,7 +7,7 @@ const SiteNavbar = props => {
   const { links } = props;
 
   return (
-    <Navbar bg="dark" variant="dark" expand="lg">
+    <Navbar className="gm_nav" bg="dark" variant="dark" expand="lg">
       <Navbar.Brand as={Link} to="/" className="navbar-brand-override">
         <span className="gm_banner_text">Eden</span>
       </Navbar.Brand>

--- a/client/src/components/style.css
+++ b/client/src/components/style.css
@@ -47,6 +47,10 @@ body {
     0 20px 20px rgba(0, 0, 0, 0.15);
 }
 
+.gm_nav {
+  flex-shrink: 0;
+}
+
 .navbar-brand-override {
   line-height: 0 !important;
 }


### PR DESCRIPTION
### Description

- This PR fixes an issue where the navbar was unusable on Safari mobile and nearly invisible on Safari. When the page content was increasing the header was shrinking. I set a property to prevent the header shrinking.
- Additionally, the link to SquareEnix's website has been removed that was added in [this PR](https://github.com/EdenServer/eden-web/pull/127)
- Finally, the margin between the navbar and the warning banner has been removed

### Testing
You'll need a few different browsers to test this. Meaning an iOS device, a Mac as well as some other browsers to ensure unbroken functionality. If you don't have any of those, you can just trust me. ;) It's only 1 line of CSS. :)