### PR TITLE
Allow searching on full item name rather than abbreviation

### DIFF
--- a/api/v1/items.js
+++ b/api/v1/items.js
@@ -8,18 +8,22 @@ const utils = require('./utils');
 router.get('/', async (req, res) => {
   const cache = await req.app.locals.cache.fetch(req.originalUrl, () => {
     const { search = '', limit = 10, offset = 0 } = req.query;
-    const items = Object.values(lists.items).filter(i => {
-      if (i.name.toLowerCase().indexOf(search.toLowerCase()) !== -1 || i.sort.toLowerCase().indexOf(search.toLowerCase()) !== -1) {
-        if (!req.app.locals.itemKeys[i.id]) {
-          console.warn(`itemid ${i.id} does not have an entry in itemKeys`);
-          return false;
-        } else {
-          return true;
+    const items = Object.values(lists.items)
+      .filter(i => {
+        if (i.name.toLowerCase().indexOf(search.toLowerCase()) !== -1 || i.sort.toLowerCase().indexOf(search.toLowerCase()) !== -1) {
+          if (!req.app.locals.itemKeys[i.id]) {
+            console.warn(`itemid ${i.id} does not have an entry in itemKeys`);
+            return false;
+          } else {
+            return true;
+          }
         }
-      }
 
-      return false;
-    });
+        return false;
+      })
+      .sort(function (a, b) {
+        return a.sort < b.sort ? -1 : a.sort > b.sort ? 1 : 0;
+      });
 
     return {
       total: items.length,

--- a/api/v1/items.js
+++ b/api/v1/items.js
@@ -9,7 +9,7 @@ router.get('/', async (req, res) => {
   const cache = await req.app.locals.cache.fetch(req.originalUrl, () => {
     const { search = '', limit = 10, offset = 0 } = req.query;
     const items = Object.values(lists.items).filter(i => {
-      if (i.name.toLowerCase().indexOf(search.toLowerCase()) !== -1) {
+      if (i.name.toLowerCase().indexOf(search.toLowerCase()) !== -1 || i.sort.toLowerCase().indexOf(search.toLowerCase()) !== -1) {
         if (!req.app.locals.itemKeys[i.id]) {
           console.warn(`itemid ${i.id} does not have an entry in itemKeys`);
           return false;

--- a/tests/e2e/jest-puppeteer.config.js
+++ b/tests/e2e/jest-puppeteer.config.js
@@ -8,5 +8,6 @@ module.exports = {
   server: {
     command: 'npm run start',
     port: 8081,
+    launchTimeout: 10000
   },
 };

--- a/tests/e2e/jest-puppeteer.config.js
+++ b/tests/e2e/jest-puppeteer.config.js
@@ -8,6 +8,6 @@ module.exports = {
   server: {
     command: 'npm run start',
     port: 8081,
-    launchTimeout: 10000
+    launchTimeout: 10000,
   },
 };


### PR DESCRIPTION
The website currently forces you to search for items using the in-game abbreviation, this will allow for searching on the full item name.

Ex:
"Scorpion Harness +1" can now be searched using the term "scorpion harness" rather than "scp."

Resolves #97 