### PR TITLE
Only show players active in the last 30 days in item bazaar listings

### DIFF
--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -78,8 +78,10 @@ const getBazaars = async (query, itemname, limit = 300) => {
     const statement = `SELECT charname, bazaar, IF(s.charid IS NULL, 0, 1) AS online_flag FROM char_inventory AS i
             JOIN item_basic AS b ON b.itemid = i.itemid
             JOIN chars AS c ON c.charid = i.charid
+            JOIN accounts a ON a.id = c.accid
             LEFT JOIN accounts_sessions s on c.charid = s.charid
-            WHERE bazaar != 0 AND b.name = ? ORDER BY CASE WHEN online_flag = 1 THEN 1 ELSE 2 END, bazaar, charname ASC LIMIT ?;`;
+            WHERE bazaar != 0 AND b.name = ? AND a.timelastmodify > NOW() - INTERVAL 30 DAY
+            ORDER BY CASE WHEN online_flag = 1 THEN 1 ELSE 2 END, bazaar, charname ASC LIMIT ?;`;
     return await query(statement, [itemname, limit]);
   } catch (error) {
     console.error('Error while getting bazaars', error);


### PR DESCRIPTION
Limit the bazaar listings for an item to players online within the last 30 days, rather than all time.
Navigating to a character page directly will show their bazaar regardless of last login time.

Resolves #146 