### PR TITLE
Added Crafting to item tools

### DIFF
--- a/api/v1/lists/craftNames.js
+++ b/api/v1/lists/craftNames.js
@@ -1,0 +1,10 @@
+module.exports = {
+  Alchemy: 'Alchemy',
+  Bone: 'Bonecraft',
+  Cloth: 'Clothcraft',
+  Cook: 'Cooking',
+  Gold: 'Goldsmithing',
+  Leather: 'Leathercraft',
+  Smith: 'Smithing',
+  Wood: 'Woodworking',
+};

--- a/api/v1/lists/index.js
+++ b/api/v1/lists/index.js
@@ -4,6 +4,7 @@
  */
 const titles = require('./titles');
 const items = require('./itemNames.json');
+const crafts = require('./craftNames');
 const itemDescriptions = require('./itemDescriptions.json');
 Object.keys(itemDescriptions).forEach(itemid => {
   items[itemid].desc = itemDescriptions[itemid];
@@ -12,4 +13,5 @@ Object.keys(itemDescriptions).forEach(itemid => {
 module.exports = {
   items,
   titles,
+  crafts,
 };

--- a/api/v1/utils/crafts.js
+++ b/api/v1/utils/crafts.js
@@ -1,0 +1,74 @@
+const { items, crafts } = require('../lists');
+
+const getCraftLevels = (synth, key) => {
+  if (synth[key] != 0) {
+    synth['crafts'].push({ craft: crafts[key], level: synth[key] });
+  }
+  delete synth[key];
+};
+
+const getIngredients = (synth, key) => {
+  if (!synth[key] == 0) {
+    if (synth['ingredients'].some(e => e.id == synth[key])) {
+      var foundIndex = synth['ingredients'].findIndex(x => x.id == synth[key]);
+      synth['ingredients'][foundIndex]['count'] += 1;
+    } else {
+      synth['ingredients'].push({
+        name: items[synth[key]].name,
+        id: synth[key],
+        count: 1,
+      });
+    }
+  }
+  delete synth[key];
+};
+
+const getResults = (synth, key) => {
+  synth['results'].push({
+    name: items[synth[key]].name,
+    count: synth[key + 'Qty'],
+    type: key.replace('Result', '') == '' ? 'Normal' : key.replace('Result', ''),
+    id: synth[key],
+  });
+  delete synth[key + 'Qty'];
+  delete synth[key];
+};
+
+const sortMainCrafts = synth => {
+  synth.crafts.sort(function (a, b) {
+    var x = a.level > b.level ? -1 : 1;
+    return x;
+  });
+};
+
+const sortAllCrafts = recipes => {
+  recipes.sort(function (a, b) {
+    var x = a.crafts[0].level > b.crafts[0].level ? 1 : -1;
+    return x;
+  });
+};
+
+const parse = recipes => {
+  recipes.map(synth => {
+    synth['crafts'] = [];
+    synth['ingredients'] = [];
+    synth['results'] = [];
+    delete synth['ResultName'];
+    Object.keys(synth).map(keyName => {
+      if (Object.keys(crafts).includes(keyName)) {
+        getCraftLevels(synth, keyName);
+      } else if (keyName.startsWith('Ingredient')) {
+        getIngredients(synth, keyName);
+      } else if (keyName.startsWith('Result') && !keyName.endsWith('Qty') && synth[keyName] > 0) {
+        getResults(synth, keyName);
+      }
+    });
+    sortMainCrafts(synth);
+  });
+  sortAllCrafts(recipes);
+  return recipes;
+};
+
+module.exports = {
+  parse,
+};

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -50,9 +50,20 @@ const loadItemKeys = async query => {
 
 const getRecipeFor = async (query, itemname) => {
   try {
-    const statement = `SELECT * FROM synth_recipes AS r
-            JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid
-            WHERE b.name = ?;`;
+    const statement = `SELECT *,
+    (SELECT name from item_basic WHERE itemid = Ingredient1) AS Ingredient1Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient2) AS Ingredient2Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient3) AS Ingredient3Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient4) AS Ingredient4Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient5) AS Ingredient5Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient6) AS Ingredient6Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient7) AS Ingredient7Name,
+    (SELECT name from item_basic WHERE itemid = Ingredient8) AS Ingredient8Name,
+    (SELECT name from item_basic WHERE itemid = ResultHQ1) AS ResultHQ1Name,
+    (SELECT name from item_basic WHERE itemid = ResultHQ2) AS ResultHQ2Name,
+    (SELECT name from item_basic WHERE itemid = ResultHQ3) AS ResultHQ3Name
+    FROM synth_recipes AS r
+    JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid WHERE b.name = ?;`;
     return await query(statement, [itemname]);
   } catch (error) {
     console.error('Error while getting specific recipe', error);
@@ -141,4 +152,4 @@ const getJobs = (level, jobs, idToStr) => {
   }
 };
 
-export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs };
+export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs};

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -1,4 +1,5 @@
 import owner from '../../../client/src/owner';
+import cparse from './crafts';
 
 const loadItems = async query => {
   try {
@@ -50,21 +51,9 @@ const loadItemKeys = async query => {
 
 const getRecipeFor = async (query, itemname) => {
   try {
-    const statement = `SELECT *,
-    (SELECT name from item_basic WHERE itemid = Ingredient1) AS Ingredient1Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient2) AS Ingredient2Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient3) AS Ingredient3Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient4) AS Ingredient4Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient5) AS Ingredient5Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient6) AS Ingredient6Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient7) AS Ingredient7Name,
-    (SELECT name from item_basic WHERE itemid = Ingredient8) AS Ingredient8Name,
-    (SELECT name from item_basic WHERE itemid = ResultHQ1) AS ResultHQ1Name,
-    (SELECT name from item_basic WHERE itemid = ResultHQ2) AS ResultHQ2Name,
-    (SELECT name from item_basic WHERE itemid = ResultHQ3) AS ResultHQ3Name
-    FROM synth_recipes AS r
+    const statement = `SELECT * FROM synth_recipes AS r
     JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid WHERE b.name = ?;`;
-    return await query(statement, [itemname]);
+    return cparse.parse(await query(statement, [itemname]));
   } catch (error) {
     console.error('Error while getting specific recipe', error);
     return [];

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -152,4 +152,4 @@ const getJobs = (level, jobs, idToStr) => {
   }
 };
 
-export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs};
+export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs };

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -9,8 +9,6 @@ import Owners from './item/owners';
 import owner from '../../owner';
 import Crafts from './item/crafts';
 
-// import Crafts from './item/crafts';
-
 const charToElement = (char, line, i) => {
   switch (char) {
     case '':

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -7,6 +7,7 @@ import Ah from './item/ah';
 import Bazaar from './item/bazaar';
 import Owners from './item/owners';
 import owner from '../../owner';
+import Crafts from './item/crafts'
 
 // import Crafts from './item/crafts';
 
@@ -148,8 +149,7 @@ export default ({ history, itemname, setLoading }) => {
           Crafting
         </Accordion.Title>
         <Accordion.Content active={crafts}>
-          {/* <Crafts name={item.key} /> */}
-          In Development
+          { <Crafts name={item.key} /> }
         </Accordion.Content>
       </Accordion>
     </Segment>

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -7,7 +7,7 @@ import Ah from './item/ah';
 import Bazaar from './item/bazaar';
 import Owners from './item/owners';
 import owner from '../../owner';
-import Crafts from './item/crafts'
+import Crafts from './item/crafts';
 
 // import Crafts from './item/crafts';
 
@@ -148,9 +148,7 @@ export default ({ history, itemname, setLoading }) => {
           <Icon name="dropdown" />
           Crafting
         </Accordion.Title>
-        <Accordion.Content active={crafts}>
-          { <Crafts name={item.key} /> }
-        </Accordion.Content>
+        <Accordion.Content active={crafts}>{<Crafts name={item.key} />}</Accordion.Content>
       </Accordion>
     </Segment>
   );

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -13,76 +13,16 @@ const formatString = string =>
     })
     .join(' ');
 
-const formatRecipe = recipeToParse => {
-  //Match and correct craft name
-  const craftNames = {
-    Alchemy: 'Alchemy',
-    Bone: 'Bonecraft',
-    Cloth: 'Clothcraft',
-    Cook: 'Cooking',
-    Gold: 'Goldsmithing',
-    Leather: 'Leathercraft',
-    Smith: 'Smithing',
-    Wood: 'Woodworking',
-  };
-  //Initialize subarrays for storing enumerable data
-  recipeToParse['requirements'] = [];
-  recipeToParse['ingredients'] = [];
-  recipeToParse['results'] = [];
-
-  /*
-  All keys are iterated through to match key/value for extraction.
-  Data is then put into subarrays for further processing.
-  */
-  Object.keys(recipeToParse).map(keyName => {
-    //Collect craft level values
-    if (Object.keys(craftNames).includes(keyName) && recipeToParse[keyName] > 0) {
-      recipeToParse['requirements'].push({
-        name: craftNames[keyName],
-        level: recipeToParse[keyName],
-      });
-      //Collect ingredients
-    } else if (keyName.startsWith('Ingredient') && recipeToParse[keyName] > 0) {
-      //Checking for duplicates to condense count
-      if (recipeToParse['ingredients'].some(e => e.itemid == recipeToParse[keyName])) {
-        var foundIndex = recipeToParse['ingredients'].findIndex(x => x.itemid == recipeToParse[keyName]);
-        recipeToParse['ingredients'][foundIndex]['count'] += 1;
-      } else {
-        recipeToParse['ingredients'].push({
-          name: recipeToParse[keyName + 'Name'],
-          itemid: recipeToParse[keyName],
-          count: 1,
-        });
-      }
-      //Collect NQ/HQ Results
-    } else if (keyName.startsWith('Result') && !keyName.endsWith('Qty') && recipeToParse[keyName] > 0) {
-      recipeToParse['results'].push({
-        name: recipeToParse[keyName + 'Name'],
-        count: recipeToParse[keyName + 'Qty'],
-        type: keyName.replace('Result', '') == '' ? 'Normal' : keyName.replace('Result', ''),
-        itemid: recipeToParse[keyName],
-      });
-    }
-  });
-  //Crafts sorted by level to determine main craft.
-  recipeToParse.requirements.sort(function (a, b) {
-    var x = a.level > b.level ? -1 : 1;
-    return x;
-  });
-  return recipeToParse;
-};
-
 const Recipe = ({ recipe, index }) => {
-  recipe = formatRecipe(recipe);
   return (
     <Card>
       <Card.Content>
         <Image className="gm_image-spacer" floated="right" size="mini" src={images.item(recipe.Crystal)} />
-        <Card.Header>{`${recipe.requirements[0].name} (${recipe.requirements[0].level})`}</Card.Header>
-        {recipe.requirements.length > 1 && (
+        <Card.Header>{`${recipe.crafts[0].craft} (${recipe.crafts[0].level})`}</Card.Header>
+        {recipe.crafts.length > 1 && (
           <Card.Meta>
-            {recipe.requirements.slice(1).map((req, i) => {
-              return <div key={`req_${i}`}>{`${req.name} (${req.level})`}</div>;
+            {recipe.crafts.slice(1).map((req, i) => {
+              return <div key={`req_${i}`}>{`${req.craft} (${req.level})`}</div>;
             })}
           </Card.Meta>
         )}
@@ -90,7 +30,7 @@ const Recipe = ({ recipe, index }) => {
           {Object.values(recipe.ingredients).map((ingredient, i) => (
             <List.Item key={`ing_${index}_${i}`}>
               <List.Content>
-                <Image src={images.item(ingredient.itemid)} />
+                <Image src={images.item(ingredient.id)} />
                 {` ${formatString(ingredient.name)} ${ingredient.count === 1 ? '' : `(${ingredient.count})`}`}
               </List.Content>
             </List.Item>
@@ -103,7 +43,7 @@ const Recipe = ({ recipe, index }) => {
             <List.Item key={`res_${index}_${i}`}>
               <List.Content>
                 {`${result.type === 'Normal' ? 'NQ' : result.type}: `}
-                <Image src={images.item(result.itemid)} />
+                <Image src={images.item(result.id)} />
                 {`${result.type === 'Normal' ? result.name : formatString(result.name)} ${result.count === 1 ? '' : `(${result.count})`}`}
               </List.Content>
             </List.Item>
@@ -117,7 +57,6 @@ const Recipe = ({ recipe, index }) => {
 const Crafting = ({ name }) => {
   const [error, setError] = React.useState(false);
   const [crafts, setCrafts] = React.useState(null);
-  console.log(crafts);
 
   const fetchCrafts = () => {
     setCrafts(null);

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -13,69 +13,53 @@ const formatString = string =>
     })
     .join(' ');
 
-const formatRecipe = (recipeToParse) => {
+const formatRecipe = recipeToParse => {
   //Match and correct craft name
   const craftNames = {
-    Alchemy: "Alchemy",
-    Bone: "Bonecraft",
-    Cloth: "Clothcraft",
-    Cook: "Cooking",
-    Gold: "Goldsmithing",
-    Leather: "Leathercraft",
-    Smith: "Smithing",
-    Wood: "Woodworking",
+    Alchemy: 'Alchemy',
+    Bone: 'Bonecraft',
+    Cloth: 'Clothcraft',
+    Cook: 'Cooking',
+    Gold: 'Goldsmithing',
+    Leather: 'Leathercraft',
+    Smith: 'Smithing',
+    Wood: 'Woodworking',
   };
   //Initialize subarrays for storing enumerable data
-  recipeToParse["requirements"] = [];
-  recipeToParse["ingredients"] = [];
-  recipeToParse["results"] = [];
+  recipeToParse['requirements'] = [];
+  recipeToParse['ingredients'] = [];
+  recipeToParse['results'] = [];
 
   /*
   All keys are iterated through to match key/value for extraction.
   Data is then put into subarrays for further processing.
   */
-  Object.keys(recipeToParse).map((keyName) => {
+  Object.keys(recipeToParse).map(keyName => {
     //Collect craft level values
-    if (
-      Object.keys(craftNames).includes(keyName) &&
-      recipeToParse[keyName] > 0
-    ) {
-      recipeToParse["requirements"].push({
+    if (Object.keys(craftNames).includes(keyName) && recipeToParse[keyName] > 0) {
+      recipeToParse['requirements'].push({
         name: craftNames[keyName],
         level: recipeToParse[keyName],
       });
       //Collect ingredients
-    } else if (keyName.startsWith("Ingredient") && recipeToParse[keyName] > 0) {
+    } else if (keyName.startsWith('Ingredient') && recipeToParse[keyName] > 0) {
       //Checking for duplicates to condense count
-      if (
-        recipeToParse["ingredients"].some(
-          (e) => e.itemid == recipeToParse[keyName]
-        )
-      ) {
-        var foundIndex = recipeToParse["ingredients"].findIndex(
-          (x) => x.itemid == recipeToParse[keyName]
-        );
-        recipeToParse["ingredients"][foundIndex]["count"] += 1;
+      if (recipeToParse['ingredients'].some(e => e.itemid == recipeToParse[keyName])) {
+        var foundIndex = recipeToParse['ingredients'].findIndex(x => x.itemid == recipeToParse[keyName]);
+        recipeToParse['ingredients'][foundIndex]['count'] += 1;
       } else {
-        recipeToParse["ingredients"].push({
-          name: recipeToParse[keyName + "Name"],
+        recipeToParse['ingredients'].push({
+          name: recipeToParse[keyName + 'Name'],
           itemid: recipeToParse[keyName],
           count: 1,
         });
       }
       //Collect NQ/HQ Results
-    } else if (
-      keyName.startsWith("Result") &&
-      !keyName.endsWith("Qty") &&
-      recipeToParse[keyName] > 0
-    ) {
-      recipeToParse["results"].push({
-        name: recipeToParse[keyName + "Name"],
-        count: recipeToParse[keyName + "Qty"],
-        type:
-          keyName.replace("Result", "") == ""
-            ? "Normal"
-            : keyName.replace("Result", ""),
+    } else if (keyName.startsWith('Result') && !keyName.endsWith('Qty') && recipeToParse[keyName] > 0) {
+      recipeToParse['results'].push({
+        name: recipeToParse[keyName + 'Name'],
+        count: recipeToParse[keyName + 'Qty'],
+        type: keyName.replace('Result', '') == '' ? 'Normal' : keyName.replace('Result', ''),
         itemid: recipeToParse[keyName],
       });
     }
@@ -101,7 +85,7 @@ const Recipe = ({ recipe, index }) => {
               return <div key={`req_${i}`}>{`${req.name} (${req.level})`}</div>;
             })}
           </Card.Meta>
-          )}
+        )}
         <List>
           {Object.values(recipe.ingredients).map((ingredient, i) => (
             <List.Item key={`ing_${index}_${i}`}>


### PR DESCRIPTION
Most of the code for this feature was already in existence. This was mostly just the introduction of pulling item names from the database and formatting the response to properly work with the existing layout/code.

This was the first time I've worked with React, so it's definitely not amazing code. This was my task lisk:

- [x] Craft menu enabled and calls are being made to the endpoint.
- [x] Item names for ingredients and results returned from crafting endpoint.
- [x] Correct crystal image and item images displayed on info box.
- [x] Craft and subcraft levels displayed, sorted by level requirement. 
- [x] Ingredients grouped by count rather then shown individually.
- [ ] Able to click on an ingredient or result to view its page.
- [ ] Align all results (NQ is currently slightly offset.)
- [x] Sort recipes by main craft from lowest to highest.

The SQL I implemented is, at the very best, abysmal. I used subqueries to individually fetch each recipe and result item name. There is probably a better way to do this but I wanted to get this working before I spent more time on SQL.

![Recipe with crafts and subcraft](https://i.imgur.com/iPCZvGX.png)
![Item with multiple recipes](https://i.imgur.com/bTyH8ZT.png)

Please feel free to provide feedback, requests for changes, or anything else. I can be contacted here or through the Eden discord (where my username is Floaty.)