### PR TITLE
Conditional Darksday colour and subcraft colour change

### DIFF
--- a/client/src/components/TimeInfo.jsx
+++ b/client/src/components/TimeInfo.jsx
@@ -129,7 +129,7 @@ const TimeInfo = () => {
                 <br />
                 <span
                   style={{
-                    color: weekDays[vanaWeekDay]?.color,
+                    color: weekDays[vanaWeekDay]?.name === 'Darksday' && localStorage.getItem('theme') === 'dark' ? 'grey' : weekDays[vanaWeekDay]?.color,
                     fontWeight: 'bold',
                   }}
                 >

--- a/client/src/theme-switch.scss
+++ b/client/src/theme-switch.scss
@@ -186,3 +186,7 @@ a {
 .ui.card .content .header {
   color: $text-main;
 }
+
+.ui.card > .content > .meta {
+  color: $text-alt;
+}


### PR DESCRIPTION
Dark mode has two colour issues that I know of, Darksday is the same colour as the background and isn't able to be seen and the subcrafts are too dark.

This PR changes the subcraft text colour to the `$text-alt` colour defined in the darkmode config (`rgba(126, 126, 126, 1)`).

It also adds a conditional check to make `Darksday` appear as a grey colour instead of black if the user has darkmode enabled.

Fixes #199 