### PR TITLE
Catch URI decode errors to prevent crashes

### DIFF
--- a/api/v1/items.js
+++ b/api/v1/items.js
@@ -46,7 +46,7 @@ router.get('/:itemname/ah', async (req, res) => {
   const { itemname = '' } = req.params;
   const stack = req.query.stack === 'true' ? 1 : 0;
   const cache = await req.app.locals.cache.fetch(`${req.originalUrl}?stack=${stack}`, () => {
-    return utils.items.getLastSold(req.app.locals.query, decodeURIComponent(itemname), stack, 10);
+    return utils.items.getLastSold(req.app.locals.query, utils.items.safeDecode(itemname), stack, 10);
   });
 
   res.send(cache);
@@ -60,7 +60,7 @@ router.get('/:itemname/crafts', async (req, res) => {
     },
     () => {
       const { itemname = '' } = req.params;
-      return utils.items.getRecipeFor(req.app.locals.query, decodeURIComponent(itemname));
+      return utils.items.getRecipeFor(req.app.locals.query, utils.items.safeDecode(itemname));
     }
   );
 
@@ -70,7 +70,7 @@ router.get('/:itemname/crafts', async (req, res) => {
 router.get('/:itemname/bazaar', async (req, res) => {
   const cache = await req.app.locals.cache.fetch(req.originalUrl, () => {
     const { itemname = '' } = req.params;
-    return utils.items.getBazaars(req.app.locals.query, decodeURIComponent(itemname));
+    return utils.items.getBazaars(req.app.locals.query, utils.items.safeDecode(itemname));
   });
 
   res.send(cache);
@@ -79,7 +79,7 @@ router.get('/:itemname/bazaar', async (req, res) => {
 router.get('/:itemid/owners', async (req, res) => {
   const cache = await req.app.locals.cache.fetch(req.originalUrl, () => {
     const { itemid = 0 } = req.params;
-    return utils.items.getOwners(req.app.locals.query, parseInt(decodeURIComponent(itemid)));
+    return utils.items.getOwners(req.app.locals.query, parseInt(utils.items.safeDecode(itemid)));
   });
 
   res.send(cache);
@@ -89,7 +89,7 @@ router.get('/:itemname', async (req, res) => {
   const cache = await req.app.locals.cache.fetch(req.originalUrl, () => {
     const { itemname = '' } = req.params;
     const item = Object.values(req.app.locals.items).filter(i => {
-      return i.name.toLowerCase() === decodeURIComponent(itemname).toLowerCase();
+      return i.name.toLowerCase() === utils.items.safeDecode(itemname).toLowerCase();
     })[0];
 
     if (item) {
@@ -98,7 +98,7 @@ router.get('/:itemname', async (req, res) => {
       const stackable = Boolean(item.stackSize > 1);
       const armor = utils.items.getJobs(info.level, info.jobs, utils.chars.jobIdToString);
       return Object.assign({ armor, stackable }, response, {
-        key: decodeURIComponent(itemname).toLowerCase(),
+        key: utils.items.safeDecode(itemname).toLowerCase(),
       });
     }
   });

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -141,12 +141,12 @@ const getJobs = (level, jobs, idToStr) => {
   }
 };
 
-const safeDecode = (uri) => {
+const safeDecode = uri => {
   try {
     return decodeURIComponent(uri);
   } catch (error) {
     return '';
   }
-}
+};
 
 export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs, safeDecode };

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -141,4 +141,12 @@ const getJobs = (level, jobs, idToStr) => {
   }
 };
 
-export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs };
+const safeDecode = (uri) => {
+  try {
+    return decodeURIComponent(uri);
+  } catch (error) {
+    return '';
+  }
+}
+
+export { loadItems, loadItemKeys, getRecipeFor, getLastSold, getBazaars, getOwners, refreshOwnersCache, getJobs, safeDecode };


### PR DESCRIPTION
On local deploys certain payloads will cause the backend API to crash due to an uncaught URIError. This PR uses a function with a try/catch that returns a blank value if it fails.