### PR TITLE
Filter items shown to be level 75 or under and simplify item caching

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import mysql from 'mysql2';
 import path from 'path';
 import Cache from './api/v1/utils/cache';
 import preparedStatement from './api/v1/utils/db';
-import { loadItemKeys, loadItems, refreshOwnersCache } from './api/v1/utils/items';
+import { loadItems, refreshOwnersCache } from './api/v1/utils/items';
 import { refreshTitleCache } from './api/v1/utils/chars';
 import api from './api';
 import rateLimit from 'express-rate-limit';
@@ -46,8 +46,7 @@ app.locals.query = preparedStatement(app.locals.db);
 
 (async () => {
   try {
-    app.locals.itemsByName = await loadItems(app.locals.query);
-    app.locals.itemKeys = await loadItemKeys(app.locals.query);
+    app.locals.items = await loadItems(app.locals.query);
 
     // Setup cached results and refreshing of them
     await refreshOwnersCache(app.locals.query);


### PR DESCRIPTION
Fixes https://github.com/EdenServer/eden-web/issues/214 by filtering out items higher than level 75 from items available on the website.

Partially fixes https://github.com/EdenServer/eden-web/issues/216 by always picking the item with the lowest item ID as the main item (usually is the right one, but I think there's a few ones that aren't like this).