### PR TITLE
Ensure charid for seller is not a deleted character with same name

### DIFF
--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -131,7 +131,7 @@ const getCharCrafts = async (query, charid) => {
 
 const getCharAH = async (query, charname, limit = 10) => {
   try {
-    const charQuery = `SELECT charid FROM chars WHERE charname = ?`;
+    const charQuery = `SELECT charid FROM chars WHERE charname = ? AND deleted IS NULL LIMIT 1`;
     const charResult = await query(charQuery, [charname]);
     if (!charResult || charResult.length < 1) {
       return [];


### PR DESCRIPTION
Fixes https://github.com/EdenServer/eden-web/issues/215 and https://github.com/EdenServer/eden-web/issues/219 by skipping characters with the same name that have since been deleted.