### PR TITLE
Replace more links still using the item name with ID, and fix load issue when using name

### DIFF
--- a/api/v1/utils/chars.js
+++ b/api/v1/utils/chars.js
@@ -137,7 +137,7 @@ const getCharAH = async (query, charname, limit = 10) => {
       return [];
     }
 
-    const statement = `SELECT name, CASE WHEN stack = 1 THEN stacksize ELSE 1 END AS stack_size,
+    const statement = `SELECT item_basic.itemid, name, CASE WHEN stack = 1 THEN stacksize ELSE 1 END AS stack_size,
                               seller_name, buyer_name, sale, sell_date FROM server_auctionhouse
             JOIN item_basic on item_basic.itemid = server_auctionhouse.itemid
             WHERE sell_date != 0 AND (seller = ? OR buyer_name = ?) ORDER BY sell_date DESC LIMIT ?;`;
@@ -150,7 +150,7 @@ const getCharAH = async (query, charname, limit = 10) => {
 
 const getCharBazaar = async (query, charname) => {
   try {
-    const statement = `SELECT b.name, i.bazaar, SUM(quantity) quantity FROM char_inventory AS i
+    const statement = `SELECT b.itemid, b.name, i.bazaar, SUM(quantity) quantity FROM char_inventory AS i
             JOIN chars AS c ON c.charid = i.charid
             JOIN item_basic AS b ON b.itemid = i.itemid
             WHERE bazaar != 0 AND charname = ? GROUP BY name, bazaar

--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -52,11 +52,11 @@ const loadItems = async query => {
   }
 };
 
-const getRecipeFor = async (query, itemname) => {
+const getRecipeFor = async (query, itemid) => {
   try {
     const statement = `SELECT * FROM synth_recipes AS r
-    JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid WHERE b.name = ?;`;
-    return cparse.parse(await query(statement, [itemname]));
+    JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid WHERE b.itemid = ?;`;
+    return cparse.parse(await query(statement, [itemid]));
   } catch (error) {
     console.error('Error while getting specific recipe', error);
     return [];
@@ -80,17 +80,17 @@ const getLastSold = async (query, itemid, stack = 0, count = 10) => {
   }
 };
 
-const getBazaars = async (query, itemname, limit = 300) => {
+const getBazaars = async (query, itemid, limit = 300) => {
   try {
     const statement = `SELECT charname, bazaar, SUM(quantity) AS quantity, IF(s.charid IS NULL, 0, 1) AS online_flag FROM char_inventory AS i
             JOIN item_basic AS b ON b.itemid = i.itemid
             JOIN chars AS c ON c.charid = i.charid
             JOIN accounts a ON a.id = c.accid
             LEFT JOIN accounts_sessions s on c.charid = s.charid
-            WHERE bazaar != 0 AND b.name = ? AND a.timelastmodify > NOW() - INTERVAL 30 DAY
+            WHERE bazaar != 0 AND b.itemid = ? AND a.timelastmodify > NOW() - INTERVAL 30 DAY
             GROUP BY charname, bazaar, online_flag
             ORDER BY CASE WHEN online_flag = 1 THEN 1 ELSE 2 END, bazaar, quantity, charname ASC LIMIT ?;`;
-    return await query(statement, [itemname, limit]);
+    return await query(statement, [itemid, limit]);
   } catch (error) {
     console.error('Error while getting bazaars', error);
     return [];

--- a/client/src/components/tools/item.jsx
+++ b/client/src/components/tools/item.jsx
@@ -52,7 +52,7 @@ const descriptionWithElements = (description, line) => {
   return render;
 };
 
-export default ({ history, itemname, setLoading }) => {
+export default ({ history, itemkey, setLoading }) => {
   const params = new URLSearchParams(history.location.search);
   const stack = params.get('stack');
 
@@ -63,11 +63,11 @@ export default ({ history, itemname, setLoading }) => {
   const [crafts, setCrafts] = React.useState(false);
   const isStack = stack === 'true';
 
-  const fetchItem = itemname => {
-    if (!itemname) return;
+  const fetchItem = itemkey => {
+    if (!itemkey) return;
 
     setLoading(true);
-    apiUtil.get({ url: `/api/v1/items/${itemname}`, json: true }, (error, data) => {
+    apiUtil.get({ url: `/api/v1/items/${itemkey}`, json: true }, (error, data) => {
       setItem(data);
       setLoading(false);
     });
@@ -77,10 +77,10 @@ export default ({ history, itemname, setLoading }) => {
 
   React.useEffect(() => {
     const getStack = stack !== null ? stack : false;
-    if (itemname) {
-      fetchMemoizedItem(encodeURIComponent(itemname), getStack);
+    if (itemkey) {
+      fetchMemoizedItem(encodeURIComponent(itemkey), getStack);
     }
-  }, [itemname, stack]);
+  }, [itemkey, stack]);
 
   if (!item) {
     return (
@@ -133,21 +133,21 @@ export default ({ history, itemname, setLoading }) => {
           Auction House
         </Accordion.Title>
         <Accordion.Content active={ah}>
-          <Ah name={item.key} stack={isStack} />
+          <Ah itemid={item.id} stack={isStack} />
         </Accordion.Content>
         <Accordion.Title active={bazaar} onClick={() => setBazaar(!bazaar)}>
           <Icon name="dropdown" />
           Bazaar
         </Accordion.Title>
         <Accordion.Content active={bazaar}>
-          <Bazaar name={item.key} />
+          <Bazaar itemid={item.id} />
         </Accordion.Content>
         <Accordion.Title active={crafts} onClick={() => setCrafts(!crafts)}>
           <Icon name="dropdown" />
           Crafting
         </Accordion.Title>
         <Accordion.Content active={crafts}>
-          <Crafts name={item.key} />
+          <Crafts itemid={item.id} />
         </Accordion.Content>
       </Accordion>
     </Segment>

--- a/client/src/components/tools/item/ah.jsx
+++ b/client/src/components/tools/item/ah.jsx
@@ -3,12 +3,12 @@ import { Table, Loader } from 'semantic-ui-react';
 import { Link } from '@reach/router';
 import apiUtil from '../../../apiUtil';
 
-export default ({ name, stack }) => {
+export default ({ itemid, stack }) => {
   const [error, setError] = React.useState(false);
   const [ah, setAh] = React.useState(null);
 
   const fetchAh = () => {
-    apiUtil.get({ url: `/api/v1/items/${name}/ah?stack=${stack}` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/items/${itemid}/ah?stack=${stack}` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setAh(await res.json());
@@ -25,11 +25,11 @@ export default ({ name, stack }) => {
   const fetchMemoizedAh = React.useCallback(fetchAh);
 
   React.useEffect(() => {
-    if (name) {
+    if (itemid) {
       setAh(null);
       fetchMemoizedAh();
     }
-  }, [name, stack]);
+  }, [itemid, stack]);
 
   if (error) {
     return <p>Error fetching auction house history...</p>;

--- a/client/src/components/tools/item/bazaar.jsx
+++ b/client/src/components/tools/item/bazaar.jsx
@@ -3,13 +3,13 @@ import { Table, Loader, Icon } from 'semantic-ui-react';
 import { Link } from '@reach/router';
 import apiUtil from '../../../apiUtil';
 
-export default ({ name }) => {
+export default ({ itemid }) => {
   const [error, setError] = React.useState(false);
   const [bazaar, setBazaar] = React.useState(null);
 
   const fetchBazaar = () => {
     setBazaar(null);
-    apiUtil.get({ url: `/api/v1/items/${name}/bazaar` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/items/${itemid}/bazaar` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setBazaar(await res.json());
@@ -23,7 +23,7 @@ export default ({ name }) => {
     });
   };
 
-  React.useEffect(fetchBazaar, [name]);
+  React.useEffect(fetchBazaar, [itemid]);
 
   if (error) {
     return <p>Error fetching bazaar items...</p>;

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -52,13 +52,13 @@ const Recipe = ({ recipe, index }) => {
   );
 };
 
-const Crafting = ({ name }) => {
+const Crafting = ({ itemid }) => {
   const [error, setError] = React.useState(false);
   const [crafts, setCrafts] = React.useState(null);
 
   const fetchCrafts = () => {
     setCrafts(null);
-    apiUtil.get({ url: `/api/v1/items/${name}/crafts` }, async (error, res) => {
+    apiUtil.get({ url: `/api/v1/items/${itemid}/crafts` }, async (error, res) => {
       try {
         if (!error && res.status === 200) {
           setCrafts(await res.json());
@@ -72,7 +72,7 @@ const Crafting = ({ name }) => {
     });
   };
 
-  React.useEffect(fetchCrafts, [name]);
+  React.useEffect(fetchCrafts, [itemid]);
 
   if (error) {
     return <p>Error fetching recipes...</p>;

--- a/client/src/components/tools/itemsearch.jsx
+++ b/client/src/components/tools/itemsearch.jsx
@@ -10,7 +10,7 @@ import './item/itemStyles.css';
 const Itemsearch = ({ history }) => {
   const params = new URLSearchParams(history.location.search);
   const searchParam = params.get('search');
-  const itemname = useMatch(':itemname')?.itemname;
+  const itemkey = useMatch(':itemkey')?.itemkey;
 
   const [search, setSearch] = React.useState(searchParam || '');
   const [results, setResults] = React.useState([]);
@@ -21,7 +21,7 @@ const Itemsearch = ({ history }) => {
 
   const handleSearch = e => {
     if (e.key === 'Escape') {
-      setSearch(itemname || search || '');
+      setSearch(itemkey || search || '');
     } else if (e.key === 'Enter' && search) {
       navigate(`/tools/item?search=${search}`);
     }
@@ -54,7 +54,7 @@ const Itemsearch = ({ history }) => {
 
   const searchInput = React.useRef(null);
   React.useEffect(() => {
-    if (!itemname) {
+    if (!itemkey) {
       setSearch(searchParam || '');
       searchInput.current.focus();
 
@@ -69,7 +69,7 @@ const Itemsearch = ({ history }) => {
         fetchItems({ search: searchParam, limit: 10, offset: 0 });
       }
     }
-  }, [itemname, searchParam]);
+  }, [itemkey, searchParam]);
 
   return (
     <Segment className="gm_tools-container">
@@ -82,8 +82,8 @@ const Itemsearch = ({ history }) => {
         onKeyUp={handleSearch}
         onChange={e => setSearch(e.target.value)}
       />
-      {itemname ? (
-        <Item itemname={itemname} history={history} setLoading={setLoading} />
+      {itemkey ? (
+        <Item itemkey={itemkey} history={history} setLoading={setLoading} />
       ) : (
         <>
           <Pagination results={total} changePage={fetchItems} extra={{ search }} />
@@ -97,7 +97,7 @@ const Itemsearch = ({ history }) => {
           </List>
         </>
       )}
-      {!itemname && results.length === 0 && (
+      {!itemkey && results.length === 0 && (
         <Segment>{initial ? `No results for "${searchParam}".` : 'Begin searching an item by typing in the search box above.'}</Segment>
       )}
     </Segment>

--- a/client/src/components/tools/player/ah.jsx
+++ b/client/src/components/tools/player/ah.jsx
@@ -3,9 +3,9 @@ import { Table, Loader } from 'semantic-ui-react';
 import { Link } from '@reach/router';
 import apiUtil from '../../../apiUtil';
 
-const formatItem = (itemname, stacksize) => {
+const formatItem = (itemkey, itemname, stacksize) => {
   return (
-    <Link to={`/tools/item/${encodeURIComponent(itemname)}${parseInt(stacksize, 10) > 1 ? '?stack=true' : ''}`}>
+    <Link to={`/tools/item/${encodeURIComponent(itemkey)}${parseInt(stacksize, 10) > 1 ? '?stack=true' : ''}`}>
       {itemname
         .split('_')
         .map(string => {
@@ -73,7 +73,7 @@ export default ({ name }) => {
           return (
             <Table.Row key={`ah_history_${i}`}>
               <Table.Cell>{`${date.toLocaleDateString()} ${date.toLocaleTimeString()}`}</Table.Cell>
-              <Table.Cell>{formatItem(history.name, history.stack_size)}</Table.Cell>
+              <Table.Cell>{formatItem(history.itemid, history.name, history.stack_size)}</Table.Cell>
               <Table.Cell>{formatPlayerLink(name, history.seller_name)}</Table.Cell>
               <Table.Cell>{formatPlayerLink(name, history.buyer_name)}</Table.Cell>
               <Table.Cell>{`${history.sale.toLocaleString()}g`}</Table.Cell>

--- a/client/src/components/tools/player/bazaar.jsx
+++ b/client/src/components/tools/player/bazaar.jsx
@@ -3,9 +3,9 @@ import { Table, Loader } from 'semantic-ui-react';
 import { Link } from '@reach/router';
 import apiUtil from '../../../apiUtil';
 
-const formatItem = itemname => {
+const formatItem = (itemkey, itemname) => {
   return (
-    <Link to={`/tools/item/${encodeURIComponent(itemname)}`}>
+    <Link to={`/tools/item/${encodeURIComponent(itemkey)}`}>
       {itemname
         .split('_')
         .map(string => {
@@ -58,7 +58,7 @@ export default ({ name }) => {
       <Table.Body>
         {bazaar.map((sell, i) => (
           <Table.Row key={`ah_history_${i}`}>
-            <Table.Cell>{formatItem(sell.name)}</Table.Cell>
+            <Table.Cell>{formatItem(sell.itemid, sell.name)}</Table.Cell>
             <Table.Cell>{sell.quantity}</Table.Cell>
             <Table.Cell>{`${sell.bazaar.toLocaleString()}g`}</Table.Cell>
           </Table.Row>


### PR DESCRIPTION
Change the last few places still pointing to items by their name to use IDs as well. Also fix issue where if they were pointed to be name, they wouldn't properly fetch certain sections of the item page.

Fixes https://github.com/EdenServer/eden-web/issues/223 and https://github.com/EdenServer/eden-web/issues/224