### PR TITLE
Added links to craft ingredients/results

### DIFF
--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -28,7 +28,9 @@ const Recipe = ({ recipe, index }) => {
           {Object.values(recipe.ingredients).map((ingredient, i) => (
             <List.Item key={`ing_${index}_${i}`}>
               <List.Content>
-                <Image src={images.item(ingredient.id)} />
+                <a href={`/tools/item/${ingredient.id}`}>
+                  <Image src={images.item(ingredient.id)} />
+                </a>
                 {` ${formatString(ingredient.name)} ${ingredient.count === 1 ? '' : `(${ingredient.count})`}`}
               </List.Content>
             </List.Item>
@@ -41,7 +43,9 @@ const Recipe = ({ recipe, index }) => {
             <List.Item key={`res_${index}_${i}`}>
               <List.Content>
                 {`${result.type === 'Normal' ? 'NQ' : result.type}: `}
-                <Image src={images.item(result.id)} />
+                <a href={`/tools/item/${result.id}`}>
+                  <Image src={images.item(result.id)} />
+                </a>
                 {`${result.type === 'Normal' ? result.name : formatString(result.name)} ${result.count === 1 ? '' : `(${result.count})`}`}
               </List.Content>
             </List.Item>

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from '@reach/router';
 import { Image, Card, List, Loader } from 'semantic-ui-react';
 import apiUtil from '../../../apiUtil';
 import images from '../../../images';
@@ -28,9 +29,9 @@ const Recipe = ({ recipe, index }) => {
           {Object.values(recipe.ingredients).map((ingredient, i) => (
             <List.Item key={`ing_${index}_${i}`}>
               <List.Content>
-                <a href={`/tools/item/${ingredient.id}`}>
+                <Link to={`/tools/item/${ingredient.id}`}>
                   <Image src={images.item(ingredient.id)} />
-                </a>
+                </Link>
                 {` ${formatString(ingredient.name)} ${ingredient.count === 1 ? '' : `(${ingredient.count})`}`}
               </List.Content>
             </List.Item>
@@ -43,9 +44,9 @@ const Recipe = ({ recipe, index }) => {
             <List.Item key={`res_${index}_${i}`}>
               <List.Content>
                 {`${result.type === 'Normal' ? 'NQ' : result.type}: `}
-                <a href={`/tools/item/${result.id}`}>
+                <Link to={`/tools/item/${result.id}`}>
                   <Image src={images.item(result.id)} />
-                </a>
+                </Link>
                 {`${result.type === 'Normal' ? result.name : formatString(result.name)} ${result.count === 1 ? '' : `(${result.count})`}`}
               </List.Content>
             </List.Item>

--- a/sql/tables/item_basic.sql
+++ b/sql/tables/item_basic.sql
@@ -3838,7 +3838,6 @@ INSERT INTO `item_basic` VALUES (4082,0,'piece_of_moonlight_coral','moonlight_co
 INSERT INTO `item_basic` VALUES (4083,0,'handful_of_beryllium_arrowheads','ber._arrowheads',99,4,0,0,0);
 INSERT INTO `item_basic` VALUES (4084,0,'bag_of_mixed_fletchings','mixed_fletchings',99,4,0,0,0);
 INSERT INTO `item_basic` VALUES (4085,0,'handful_of_beryllium_bolt_heads','ber._bolt_heads',99,4,0,0,0);
-INSERT INTO `item_basic` VALUES (4086,0,'lustreless_scale','lustreless_scale',99,4,46,1,0);
 INSERT INTO `item_basic` VALUES (4094,0,'bowl_of_goblin_stew_880','goblin_stew_880',1,61520,0,0,0);
 INSERT INTO `item_basic` VALUES (4095,0,'bismuth_sheet','bismuth_sheet',12,4,38,0,0);
 INSERT INTO `item_basic` VALUES (4096,0,'fire_crystal','fire_crystal',12,516,35,0,13);
@@ -7453,7 +7452,6 @@ INSERT INTO `item_basic` VALUES (10070,0,'♪raaz','♪raaz',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10071,0,'♪levitus','♪levitus',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10072,0,'♪adamantoise','♪adamantoise',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10073,0,'♪dhalmel','♪dhalmel',1,61504,0,0,0);
-INSERT INTO `item_basic` VALUES (10074,0,'♪doll','♪doll',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10112,0,'cipher_of_zeids_alter_ego','cipher_zeid',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10113,0,'cipher_of_lions_alter_ego','cipher_lion',1,61504,0,0,0);
 INSERT INTO `item_basic` VALUES (10114,0,'cipher_of_tenzens_alter_ego','cipher_tenzen',1,61504,0,0,0);


### PR DESCRIPTION
The recent change to how item pages are accessed by ID made it a lot easier to link to them. This just wraps the ingredient/result image with a hyperlink to its item page.