### PR TITLE
Add check for valid item id to prevent 500 errors

### DIFF
--- a/api/v1/utils/items.js
+++ b/api/v1/utils/items.js
@@ -54,6 +54,9 @@ const loadItems = async query => {
 
 const getRecipeFor = async (query, itemid) => {
   try {
+    if (!itemid) {
+      return [];
+    }
     const statement = `SELECT * FROM synth_recipes AS r
     JOIN item_basic AS b ON r.result = b.itemid OR resultHQ1 = b.itemid OR resultHQ2 = b.itemid OR resultHQ3 = b.itemid WHERE b.itemid = ?;`;
     return cparse.parse(await query(statement, [itemid]));
@@ -82,6 +85,9 @@ const getLastSold = async (query, itemid, stack = 0, count = 10) => {
 
 const getBazaars = async (query, itemid, limit = 300) => {
   try {
+    if (!itemid) {
+      return [];
+    }
     const statement = `SELECT charname, bazaar, SUM(quantity) AS quantity, IF(s.charid IS NULL, 0, 1) AS online_flag FROM char_inventory AS i
             JOIN item_basic AS b ON b.itemid = i.itemid
             JOIN chars AS c ON c.charid = i.charid


### PR DESCRIPTION
While messing around with the new changes I found an interesting error that happens when you pass in an invalid value to certain item endpoints on the API.

Example query: `GET /api/v1/items/--/bazaar`

Result: `TypeError: Bind parameters must not contain undefined. To pass SQL NULL specify JS null`

504 error on local env causing the backend API to crash (similar to the safeDecode PR I made before.)

The issue is caused when `getItemIdFromKey` calls `getItem` and tries to return a value from either a name or ID with `req.app.locals.items.byId[safeKey] ?? req.app.locals.items.byName[safeKey]`.

Since the value passed in is neither a name or valid ID, it will return undefined for both options.

Undefined is then passed to `getBazaars` which (understandably) does not know what to do with it. This only affects `/bazaar` and `/crafts` since `getLastSold` and `getOwners` have a check to make sure the ID actually exists or is not null. I added that to the other item endpoints in this PR.