### PR TITLE
Active daily characters

### DIFF
--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -44,12 +44,12 @@ router.get('/active', async (req, res) => {
           'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 14 DAY) AND CURRENT_TIMESTAMP GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
-          return res.send(404);
+          return res.status(404).send();
         }
         const sum = activeDays.reduce((s, day) => s + parseInt(day.active_players, 10), 0);
-        res.send(Math.round(sum / activeDays.length).toString());
+        res.status(200).send(Math.round(sum / activeDays.length).toString());
       } catch {
-        return res.send(500);
+        return res.status(500).send();
       }
     }
   );

--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -41,7 +41,7 @@ router.get('/active', async (req, res) => {
     async () => {
       try {
         const activeDays = await req.app.locals.query(
-          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 14 DAY) AND CURRENT_TIMESTAMP GROUP BY date;'
+          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
           return res.send(404);
@@ -51,7 +51,6 @@ router.get('/active', async (req, res) => {
       } catch {
         return res.send(500);
       }
-      return res.status(200).send('504');
     }
   );
 

--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -41,7 +41,7 @@ router.get('/active', async (req, res) => {
     async () => {
       try {
         const activeDays = await req.app.locals.query(
-          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord GROUP BY date;'
+          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 14 DAY) AND CURRENT_TIMESTAMP GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
           return res.send(404);

--- a/client/src/components/tools/OnlineList.jsx
+++ b/client/src/components/tools/OnlineList.jsx
@@ -30,6 +30,7 @@ class OnlineList extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
+      active: null,
       status: null,
       players: [],
       online: '0',
@@ -52,6 +53,12 @@ class OnlineList extends React.PureComponent {
         this.setState({ status, online: 0 });
       }
     });
+    apiUtil.get({ url: '/api/v1/misc/active' }, async (error, res) => {
+      console.log(error, res.status);
+      if (error == null && res.status === 200) {
+        this.setState({ active: await res.text() });
+      }
+    });
   }
 
   fetchChars({ limit, offset }) {
@@ -69,7 +76,7 @@ class OnlineList extends React.PureComponent {
   }
 
   render() {
-    const { status, players, online, loading } = this.state;
+    const { active, status, players, online, loading } = this.state;
     return (
       <Segment className="gm_tools-container">
         <Segment>
@@ -77,7 +84,15 @@ class OnlineList extends React.PureComponent {
         </Segment>
 
         <Segment.Group className="gm_online-count" raised>
-          <Segment>{online} Characters Online</Segment>
+          <Segment>
+            <span>{online} characters online </span>
+            {active != null && (
+              <span data-tooltip="Daily average active characters calculated\nby averaging sums of unique characters that have logged in during the last 14 days. Characters that stay logged in multiple days at a time will not be reflected in this count as they need to manually log in for their character to count for the day's average.\ntest">
+                {' '}
+                | {active} active daily
+              </span>
+            )}
+          </Segment>
           <Pagination perPageDefault={10} results={parseInt(online, 10)} changePage={this.fetchChars} />
 
           <Segment>

--- a/client/src/components/tools/OnlineList.jsx
+++ b/client/src/components/tools/OnlineList.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, Segment, Icon, Loader, Table } from 'semantic-ui-react';
+import { Image, Segment, Icon, Loader, Table, Popup } from 'semantic-ui-react';
 import { navigate } from '@reach/router';
 
 import Pagination from '../pagination';
@@ -85,12 +85,17 @@ class OnlineList extends React.PureComponent {
 
         <Segment.Group className="gm_online-count" raised>
           <Segment>
-            <span>{online} characters online </span>
+            {online} characters online
             {active != null && (
-              <span data-tooltip="Daily average active characters calculated\nby averaging sums of unique characters that have logged in during the last 14 days. Characters that stay logged in multiple days at a time will not be reflected in this count as they need to manually log in for their character to count for the day's average.\ntest">
+              <>
                 {' '}
-                | {active} active daily
-              </span>
+                | {active} active daily{' '}
+                <Popup
+                  on="hover"
+                  content="Daily average active characters calculated by averaging sums of unique characters that have logged in during the last 14 days. Characters that stay logged in multiple days at a time will not be reflected in this count as they need to manually log in for their character to count for the day's average."
+                  trigger={<Icon name="info circle" />}
+                />
+              </>
             )}
           </Segment>
           <Pagination perPageDefault={10} results={parseInt(online, 10)} changePage={this.fetchChars} />

--- a/sql/tables/audit_iprecord.sql
+++ b/sql/tables/audit_iprecord.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS `audit_iprecord`;
+CREATE TABLE `audit_iprecord` (
+  `login_time` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `charid` int(10) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## description
This PR adds "average daily characters" which takes a 14-day average of characters that have logged on during this time. It is cached every 24 hours.

## text view + tooltip on info circle hover
<img width="260" alt="view" src="https://user-images.githubusercontent.com/6099499/189552993-50131be9-3326-4dbc-9349-60b7ac6fe16b.png">
<img width="479" alt="tooltip" src="https://user-images.githubusercontent.com/6099499/189553015-6b9f3ee5-0015-4020-847a-66675081751b.png">

## queries on the back end:
For testing I had an existing data set of users that were logged in at a maintenance a long while back. I used that data to pull from but only 2 days worth of log-in sessions. Because the logs were old I ran a few queries to show the production query will work and removed the `WHERE` clause. Additionally, not shown in these queries, I replaced these two calculated `DATETIME` variables with old hardcoded timestamps to ensure this did work.
<img width="445" alt="query" src="https://user-images.githubusercontent.com/6099499/189553136-17ba3c1a-a0b0-4c36-9f79-26b166d417bd.png">
