### PR TITLE
lag daily active character days by 1 day

### DIFF
--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -41,7 +41,7 @@ router.get('/active', async (req, res) => {
     async () => {
       try {
         const activeDays = await req.app.locals.query(
-          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 14 DAY) AND CURRENT_TIMESTAMP GROUP BY date;'
+          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 DAY) AND DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY) GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
           return res.status(404).send();

--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -41,7 +41,7 @@ router.get('/active', async (req, res) => {
     async () => {
       try {
         const activeDays = await req.app.locals.query(
-          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 DAY) AND DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY) GROUP BY date;'
+          'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN CAST(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 DAY) AS DATE) AND CAST(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY) AS DATE) GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
           return res.status(404).send();

--- a/client/src/components/tools/OnlineList.jsx
+++ b/client/src/components/tools/OnlineList.jsx
@@ -94,7 +94,7 @@ class OnlineList extends React.PureComponent {
                 | {active} active daily{' '}
                 <Popup
                   on="hover"
-                  content="Daily average active characters calculated by averaging sums of unique characters that have logged in during the last 14 days. Characters that stay logged in multiple days at a time will not be reflected in this count as they need to manually log in for their character to count for the day's average."
+                  content="Daily average active characters calculated by averaging sums of unique characters that have logged in during the last full 14 days. Characters that stay logged in multiple days at a time will not be reflected in this count as they need to manually log in for their character to count for the day's average."
                   trigger={<Icon name="info circle" />}
                 />
               </>


### PR DESCRIPTION
I was thinking of this while looking at the query. Pending on when the query gets requested post-cache this may be only a few logins. Such as if the query gets pulled shortly after midnight. This update lags the days to pull by 1 in order to get complete days.

In addition, this casts datetime as date in the where clause so it doesn't query partial days.

I tested on old data with hardcoded DATE strings. I don't have a full data set to test with.