### PR TITLE
Re-obtain pattern if result set has a length of 0

### DIFF
--- a/api/v1/utils/pattern.ts
+++ b/api/v1/utils/pattern.ts
@@ -1,5 +1,5 @@
 export default class Pattern {
-  private pattern: number;
+  private pattern: any;
   private date: Date;
   private day: number;
 
@@ -11,7 +11,7 @@ export default class Pattern {
 
   async isValidPattern(): Promise<Boolean> {
     await this.updateDate();
-    if ((await this.patternShouldChange()) || this.pattern == -1) {
+    if ((await this.patternShouldChange()) || typeof this.pattern != 'object' || this.pattern.length == 0) {
       this.day = this.date.getDay();
       return false;
     } else {


### PR DESCRIPTION
In the unlikely occurence that the backend tries to pull the pattern during the small window where the game server is changing it, a blank result set will be stored resulting in no GP items being displayed for the full day. This PR aims to fix this by defining an invalid pattern as one that is not an object or an object that has a length of 0.