### PR TITLE
Handle pattern 0 and misc. clean-up

### DIFF
--- a/api/v1/utils/guilds.js
+++ b/api/v1/utils/guilds.js
@@ -12,8 +12,12 @@ async function getPattern(query, patternCache) {
   if (await patternCache.isValidPattern()) {
     return await patternCache.get();
   } else {
-    const pattern = await query('SELECT value FROM server_variables WHERE name = "[GUILD]pattern"');
-    await patternCache.update(pattern);
+    const queryResult = await query('SELECT value FROM server_variables WHERE name = "[GUILD]pattern"');
+    if (queryResult && queryResult.length > 0) {
+      patternCache.set(queryResult[0].value);
+    } else {
+      patternCache.set(0);
+    }
     return await patternCache.get();
   }
 }
@@ -80,7 +84,7 @@ const fetchGuildItems = async (query, patternCache) => {
     const statement = `SELECT guildid, itemid, rank, points, max_points
     FROM guild_item_points
     WHERE pattern = ?;`;
-    const results = await query(statement, [`${pattern[0].value}`]);
+    const results = await query(statement, [pattern]);
     const gpitems = sortGuildItems(results);
     const parseditems = parseGuildItems(gpitems);
     return parseditems;

--- a/api/v1/utils/pattern.ts
+++ b/api/v1/utils/pattern.ts
@@ -1,5 +1,5 @@
 export default class Pattern {
-  private pattern: any;
+  private pattern: number;
   private date: Date;
   private day: number;
 
@@ -10,8 +10,8 @@ export default class Pattern {
   }
 
   async isValidPattern(): Promise<Boolean> {
-    await this.updateDate();
-    if ((await this.patternShouldChange()) || typeof this.pattern != 'object' || this.pattern.length == 0) {
+    this.updateDate();
+    if (this.patternShouldChange() || this.pattern == -1) {
       this.day = this.date.getDay();
       return false;
     } else {
@@ -19,22 +19,22 @@ export default class Pattern {
     }
   }
 
-  private async patternShouldChange() {
+  private patternShouldChange() {
     if (this.date.getDay() != this.day && (this.date.getHours() > 0 || this.date.getMinutes() >= 15)) {
       return true;
     }
     return false;
   }
 
-  private async updateDate() {
+  private updateDate() {
     this.date = new Date(this.getJPTime());
   }
 
-  async update(pattern: number) {
+  set(pattern: number) {
     this.pattern = pattern;
   }
 
-  async get(): Promise<any> {
+  get(): number {
     return this.pattern;
   }
 


### PR DESCRIPTION
When the pattern is 0, there will be no database row for `[GUILD]pattern`, since server variables are deleted when set to 0.

Handling default to 0 when the row is missing with this PR.

Also:

* Made the pattern cache hold the pattern as a `number` instead of the direct result of the server variable query.
* Removed unnecessary async/awaits.
