### PR TITLE
Add tooltip containing crystal name on hover in craft results

### DIFF
--- a/api/v1/utils/crafts.js
+++ b/api/v1/utils/crafts.js
@@ -54,6 +54,7 @@ const parse = recipes => {
     synth['ingredients'] = [];
     synth['results'] = [];
     delete synth['ResultName'];
+    synth['CrystalName'] = items[synth['Crystal']].name;
     Object.keys(synth).map(keyName => {
       if (Object.keys(crafts).includes(keyName)) {
         getCraftLevels(synth, keyName);

--- a/client/src/components/tools/item/crafts.jsx
+++ b/client/src/components/tools/item/crafts.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from '@reach/router';
-import { Image, Card, List, Loader } from 'semantic-ui-react';
+import { Image, Card, List, Loader, Popup } from 'semantic-ui-react';
 import apiUtil from '../../../apiUtil';
 import images from '../../../images';
 
@@ -16,7 +16,9 @@ const Recipe = ({ recipe, index }) => {
   return (
     <Card>
       <Card.Content>
-        <Image className="gm_image-spacer" floated="right" size="mini" src={images.item(recipe.Crystal)} />
+        <Link to={`/tools/item/${recipe.Crystal}`}>
+          <Popup content={recipe.CrystalName} trigger={<Image className="gm_image-spacer" floated="right" size="mini" src={images.item(recipe.Crystal)} />} />
+        </Link>
         <Card.Header>{`${recipe.crafts[0].craft} (${recipe.crafts[0].level})`}</Card.Header>
         {recipe.crafts.length > 1 && (
           <Card.Meta>


### PR DESCRIPTION
Resolves #246 

This PR adds in a tooltip that appears when you hover over the crystal with your mouse, showing the name of the crystal. It also allows you to click the crystal to view its AH page. This should help people differentiate the different crystals as it is apparently difficult for colorblind people to tell them apart.

![image](https://user-images.githubusercontent.com/39352103/217697883-3d74c424-df26-4330-9f4c-830e0daa5a50.png)