### PR TITLE
About&Install Page Changes

### DIFF
--- a/client/src/components/about/index.jsx
+++ b/client/src/components/about/index.jsx
@@ -83,11 +83,6 @@ const About = () => {
                   <td>technical limitations / cheat prevention</td>
                 </tr>
                 <tr>
-                  <td>Original difficulty CoP missions</td>
-                  <td>Era difficulty CoP missions and era item flags</td>
-                  <td>teamwork</td>
-                </tr>
-                <tr>
                   <td>Mobs that link automatically dirty exp to person that linked</td>
                   <td>Mobs did not dirty exp until an action was performed on them</td>
                   <td>teamwork</td>
@@ -95,17 +90,7 @@ const About = () => {
                 <tr>
                   <td>Some mobs do not reset their window when the server is reset</td>
                   <td>Some mobs windows would reset when a server was reset or crashed</td>
-                  <td>economy</td>
-                </tr>
-                <tr>
-                  <td>Level Sync</td>
-                  <td>No Level Sync</td>
-                  <td>teamwork</td>
-                </tr>
-                <tr>
-                  <td>Mythic Weapons (currently unavailable)</td>
-                  <td>Mythic weapons did not exist</td>
-                  <td>toau content</td>
+                  <td>potential crashes</td>
                 </tr>
               </tbody>
             </table>

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -36,8 +36,8 @@ function install(props) {
         <Col>
           <InfoDisplay title="Account Registration">
             <Card.Text>
-              The bootloader (black login screen) supports registering an account. If you are prompted for a registration code, one can be obtained from
-              players who have accumulated 120 hours (5 days) of playtime and who's current job is level 15 or greater. Make sure you have Eden completely installed
+              The bootloader (black login screen) supports registering an account. If you are prompted for a registration code, one can be obtained from players
+              who have accumulated 120 hours (5 days) of playtime and who's current job is level 15 or greater. Make sure you have Eden completely installed
               before requesting one. The easiest way to get a registration code is to join&nbsp;
               <a href={info.discord} rel="noopener noreferrer" target="_blank">
                 our Discord

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -42,7 +42,7 @@ function install(props) {
               <a href={info.discord} rel="noopener noreferrer" target="_blank">
                 our Discord
               </a>
-              &nbsp;, then request a code in the #new-players channel.
+              &nbsp; and request a code in the #new-players channel.
             </Card.Text>
           </InfoDisplay>
         </Col>

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -37,7 +37,7 @@ function install(props) {
           <InfoDisplay title="Account Registration">
             <Card.Text>
               The bootloader (black login screen) supports registering an account. If you are prompted for a registration code, one can be obtained from players
-              who have accumulated 120 hours (5 days) of playtime and who's current job is level 15 or greater. Make sure you have Eden completely installed
+              who have accumulated 120 hours (5 days) of playtime and whose current job is level 15 or greater. Make sure you have Eden completely installed
               before requesting one. The easiest way to get a registration code is to join&nbsp;
               <a href={info.discord} rel="noopener noreferrer" target="_blank">
                 our Discord

--- a/client/src/components/install.jsx
+++ b/client/src/components/install.jsx
@@ -15,7 +15,7 @@ function install(props) {
             <Card.Text>
               First, you&apos;ll need to&nbsp;
               <a href={info.source1} rel="noopener noreferrer" target="_blank">
-                download the Eden Installer v5.0
+                download the Eden Installer
               </a>
               &nbsp; to connect to Eden. You do not need to install retail FFXI first—this install will take care of everything.
             </Card.Text>
@@ -36,13 +36,13 @@ function install(props) {
         <Col>
           <InfoDisplay title="Account Registration">
             <Card.Text>
-              The bootloader (black login screen) supports registering an account. Registration requires a 7-digit code that can be obtained from existing
-              players who have accumulated 120 hours (5 days) of playtime and main job is level 15 or greater. Make sure you have Eden completely installed
-              before requesting one. The easiest wa;y to get a registration code is to join&nbsp;
+              The bootloader (black login screen) supports registering an account. If you are prompted for a registration code, one can be obtained from
+              players who have accumulated 120 hours (5 days) of playtime and who's current job is level 15 or greater. Make sure you have Eden completely installed
+              before requesting one. The easiest way to get a registration code is to join&nbsp;
               <a href={info.discord} rel="noopener noreferrer" target="_blank">
                 our Discord
               </a>
-              &nbsp; and then request a code in the #new-players channel.
+              &nbsp;, then request a code in the #new-players channel.
             </Card.Text>
           </InfoDisplay>
         </Col>
@@ -50,13 +50,13 @@ function install(props) {
 
       <Row className="mt-3">
         <Col>
-          <InfoDisplay title="Coming back / migrating from another private server" className="mt-3">
+          <InfoDisplay title="Coming back from another private server" className="mt-3">
             <Card.Text>
               You will need to download&nbsp;
               <a href={info.bootloader} rel="noopener noreferrer" target="_blank">
-                our modified bootloader&nbsp;
+                our modified bootloader&nbsp;.
               </a>
-              if your client version is older than our 5.0 installer. You may want to visit our tech-support channel on&nbsp;
+              You may want to visit our tech-support channel on&nbsp;
               <a href={info.discord} rel="noopener noreferrer" target="_blank">
                 our Discord server
               </a>
@@ -69,12 +69,8 @@ function install(props) {
               <li>We do not officially support Windower, but you may find some help getting it set up in our tech-support Discord channel.</li>
 
               <li>
-                Move <b>edenxi.exe</b> to your Ashita <b>ffxi-bootmod</b>&nbsp; directory. The default folder for this is&nbsp;
+                Move <b>xiloader.exe</b> to your Ashita <b>ffxi-bootmod</b>&nbsp; directory. The default folder for this is&nbsp;
                 <b>~\\Program Files (x86)\PlayOnline\Ashita\ffxi-bootmod</b>
-              </li>
-
-              <li>
-                DO NOT rename <b>edenxi.exe</b> or it will not work.
               </li>
 
               <li>Open your Ashita configuration, by right-clicking a profile and then clicking &quot;Edit configuration&quot;.</li>
@@ -82,7 +78,7 @@ function install(props) {
               <li>
                 In the File section you may see something like&nbsp;
                 <b>.\\ffxi-bootmod\\pol.exe</b>. Ensure that this is changed to&nbsp;
-                <b>.\\ffxi-bootmod\\edenxi.exe</b>
+                <b>.\\ffxi-bootmod\\xiloader.exe</b>
               </li>
 
               <li>


### PR DESCRIPTION
Changed Install page text to reference registration codes not always being required 
Removed some install page text to clear up installation issues people have had 
Removed things on About page that are now considered era (or have been fixed)