### PR TITLE
Enable account features

### DIFF
--- a/api/v1/accounts.js
+++ b/api/v1/accounts.js
@@ -9,14 +9,24 @@ const { getJWTForAccountId } = require('./utils/accounts');
 
 const validate = (req, res, next) => {
   const token = req.headers.authorization.replace(/^Bearer\s/, '');
-  jwt.verify(token, process.env.JWT_SECRET, (error, decoded) => {
-    if (!error) {
-      req.jwt = decoded;
-      next();
-    } else {
-      res.status(401).send();
+  jwt.verify(
+    token,
+    process.env.JWT_SECRET,
+    {
+      algorithms: ['HS512'],
+      clockTolerance: 0,
+      ignoreExpiration: false,
+      maxAge: '30h',
+    },
+    (error, decoded) => {
+      if (!error) {
+        req.jwt = decoded;
+        next();
+      } else {
+        res.status(401).send();
+      }
     }
-  });
+  );
 };
 
 router.get('/profile', validate, async (req, res) => {

--- a/api/v1/index.js
+++ b/api/v1/index.js
@@ -2,13 +2,13 @@ const { Router } = require('express');
 
 const router = Router();
 
-// const accounts = require('./accounts');
+const accounts = require('./accounts');
 const chars = require('./chars');
 const items = require('./items');
 const misc = require('./misc');
 const guilds = require('./guilds');
 
-// router.use('/accounts', accounts);
+router.use('/accounts', accounts);
 router.use('/chars', chars);
 router.use('/items', items);
 router.use('/misc', misc);

--- a/api/v1/utils/accounts.js
+++ b/api/v1/utils/accounts.js
@@ -1,20 +1,46 @@
 const jwt = require('jsonwebtoken');
 
+const privileges = [
+  'PLAYER', // 1
+  'UNUSED1', // 2
+  'UNUSED2', // 4
+  'UNUSED3', // 8
+  'UNUSED4', // 16
+  'UNUSED5', // 32
+  'UNUSED6', // 64
+  'UNUSED7', // 128
+];
+
+const getPrivileges = mask => {
+  const userPrivileges = [];
+  for (let i = 0; i < 8; i++) {
+    const privilege = Math.pow(2, i);
+    if ((mask & privilege) === privilege) {
+      userPrivileges.push(privileges[i]);
+    }
+  }
+
+  return userPrivileges;
+};
+
 const getJWTForAccountId = async (query, accid) => {
   try {
     const statement = 'SELECT * FROM accounts WHERE `id` = ?;';
     const results = await query(statement, [accid]);
     if (results.length === 1) {
-      const { id, login, email, timecreate, timelastmodify } = results[0];
+      const { id, login, email, priv, timecreate, timelastmodify } = results[0];
       const token = {
         id,
         login,
         email,
         timecreate,
         timelastmodify,
-        iss: 'https://edenxi.com',
+        privileges: getPrivileges(priv),
       };
-      return jwt.sign(token, process.env.JWT_SECRET, { expiresIn: '1h' });
+      return jwt.sign(token, process.env.JWT_SECRET, {
+        algorithm: 'HS512',
+        expiresIn: '30h',
+      });
     } else {
       return null;
     }

--- a/client/src/components/accounts/login.jsx
+++ b/client/src/components/accounts/login.jsx
@@ -23,9 +23,9 @@ export default ({ error, login, changePage }) => {
         <Button floated="right" primary onClick={() => login(username, password)}>
           Login
         </Button>
-        <Button size="mini" basic onClick={changePage}>
+        {/* <Button size="mini" basic onClick={changePage}>
           New Account
-        </Button>
+        </Button> */}
       </Form.Field>
     </Form>
   );

--- a/client/src/components/accounts/profile.jsx
+++ b/client/src/components/accounts/profile.jsx
@@ -12,7 +12,7 @@ export default ({ user, logout, reload }) => {
   const updateField = (field, value) => {
     apiUtil.put(
       {
-        url: `api/v1/accounts/${field}`,
+        url: `/api/v1/accounts/${field}`,
         headers: { [field]: value },
       },
       (error, res) => {

--- a/client/src/components/tools.jsx
+++ b/client/src/components/tools.jsx
@@ -23,7 +23,7 @@ const Tools = () => {
     <div className="gm_tools">
       <div className="gm_tools-content">
         <Menu pointing className="wrapped">
-          <TabItem to="account" disabled activeTab={activeTab}>
+          <TabItem to="account" activeTab={activeTab}>
             User Management
           </TabItem>
           <TabItem to="online" activeTab={activeTab}>
@@ -45,7 +45,7 @@ const Tools = () => {
         <Router>
           <OnlineList path="/" />
           <OnlineList path="online" />
-          {/* <Accounts path="account" /> */}
+          <Accounts path="account" />
           <Itemsearch path="item/*" history={history} />
           <Playersearch path="player/*" history={history} />
           <YellTab path="yells" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "rimraf": "^3.0.2",
         "ts-jest": "^27.0.0",
         "ts-node": "^8.10.1",
-        "ts-node-dev": "^1.0.0-pre.44",
+        "ts-node-dev": "2.0.0",
         "typescript": "4.9.5"
       }
     },
@@ -2615,6 +2615,31 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
@@ -2667,33 +2692,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -14656,20 +14673,20 @@
       }
     },
     "node_modules/ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "bin": {
@@ -14687,6 +14704,27 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-node-dev/node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ts-node-dev/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ts-node-dev/node_modules/mkdirp": {
@@ -14714,29 +14752,46 @@
       }
     },
     "node_modules/ts-node-dev/node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig": {
@@ -14963,6 +15018,12 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
@@ -17287,6 +17348,28 @@
         }
       }
     },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
@@ -17336,33 +17419,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node12": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
       "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node14": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
       "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node16": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.18",
@@ -26593,23 +26668,38 @@
       }
     },
     "ts-node-dev": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-1.1.8.tgz",
-      "integrity": "sha512-Q/m3vEwzYwLZKmV6/0VlFxcZzVV/xcgOt+Tx/VjaaRHyiBcFlV0541yrT09QjzzCxlDZ34OzKjrFAynlmtflEg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
       "dev": true,
       "requires": {
         "chokidar": "^3.5.1",
         "dynamic-dedupe": "^0.3.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "mkdirp": "^1.0.4",
         "resolve": "^1.0.0",
         "rimraf": "^2.6.1",
         "source-map-support": "^0.5.12",
         "tree-kill": "^1.2.2",
-        "ts-node": "^9.0.0",
+        "ts-node": "^10.4.0",
         "tsconfig": "^7.0.0"
       },
       "dependencies": {
+        "@cspotcode/source-map-support": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+          "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/trace-mapping": "0.3.9"
+          }
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -26626,16 +26716,23 @@
           }
         },
         "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+          "version": "10.9.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+          "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
           "dev": true,
           "requires": {
+            "@cspotcode/source-map-support": "^0.8.0",
+            "@tsconfig/node10": "^1.0.7",
+            "@tsconfig/node12": "^1.0.7",
+            "@tsconfig/node14": "^1.0.0",
+            "@tsconfig/node16": "^1.0.2",
+            "acorn": "^8.4.1",
+            "acorn-walk": "^8.1.1",
             "arg": "^4.1.0",
             "create-require": "^1.1.0",
             "diff": "^4.0.1",
             "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
+            "v8-compile-cache-lib": "^3.0.1",
             "yn": "3.1.1"
           }
         }
@@ -26816,6 +26913,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.0",
     "ts-node": "^8.10.1",
-    "ts-node-dev": "^1.0.0-pre.44",
+    "ts-node-dev": "2.0.0",
     "typescript": "4.9.5"
   }
 }


### PR DESCRIPTION
# Description
The website has account features but they were disabled when the website first launched until we got a TLS certificate. So the important part of this PR is just enabling uncommented client code. For the other changes:

- I updated the JWT to HS512 since it's more secure than the default HS256
- I extended the JWT to have a 30h token (1 day plus a 6 hour buffer) instead of the previously very restrictive 1 hour
- I added some explicit variables in case the defaults change on the `jsonwebtoken` package
- I added a `privileges` field that will query the currently not-in-use `priv` field on the `accounts` table. I am planning for it to be used to give certain users on the website administrative functions.
- Commented out the "New Account" button on the accounts tab (The API endpoint is currently intentionally short circuited)
- Updated `ts-node-dev` that was showing an error when trying to `npm i`
- Added a missing forward slash in a route on the client

# Testing
- Logged in and out 2 times.
- Examined the network tab in the developer console and exampled my JWT payload
- Clicked changed email and change password and canceled (did not execute requests)

```
{
  "id": 1,
  "login": "Godmode",
  "email": "devgodmode@edenxi.com",
  "timecreate": "2023-05-29T23:54:34.000Z",
  "timelastmodify": "2023-05-29T23:54:34.000Z",
  "privileges": [
    "PLAYER"
  ],
  "iat": 1691353411,
  "exp": 1691461411
}
```