### PR TITLE
Fix active char account endpoint

### DIFF
--- a/api/v1/misc.js
+++ b/api/v1/misc.js
@@ -44,12 +44,12 @@ router.get('/active', async (req, res) => {
           'SELECT COUNT(DISTINCT charid) AS active_players, CAST(login_time AS DATE) AS date FROM audit_iprecord WHERE login_time BETWEEN CAST(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 15 DAY) AS DATE) AND CAST(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL 1 DAY) AS DATE) GROUP BY date;'
         );
         if (activeDays == null || activeDays.length < 1) {
-          return res.status(404).send();
+          return '0';
         }
         const sum = activeDays.reduce((s, day) => s + parseInt(day.active_players, 10), 0);
         return Math.round(sum / activeDays.length).toString();
       } catch {
-        return res.status(500).send();
+        return '0';
       }
     }
   );


### PR DESCRIPTION
I discovered this bug when working on the tools section. In the "Who's online" does a query to `/api/v1/misc/active` which has a formula for how many active character in the last 14 days. If there is an error or there is no active characters in the last 14 days it was supposed to send to the client an error. However, the function was returning the string to the simple cache setter. Because the return set the cache and not response to the client the server crashes since we are setting the header again when we send the cache.

We never see this on production or the test server because we always have someone who has logged on in the last 14 days. To fix this I just have it return a string of `0` to the cache.