### PR TITLE
Updating backup install link

### DIFF
--- a/api/v1/config.js
+++ b/api/v1/config.js
@@ -225,7 +225,7 @@ module.exports = {
   ],
   install: {
     source1: 'https://bit.ly/Eden535',
-    source2: 'https://bit.ly/Eden534',
+    source2: 'https://bit.ly/Eden535Backup',
     bootloader: 'https://github.com/EdenServer/xiloader/releases/latest/download/xiloader.exe',
     discord: 'https://discord.gg/S3EAWr2Jec',
   },


### PR DESCRIPTION
Old backup link was to 534 which didn't have updated .dat mods and renamer. Upgraded my Drive so I could host same versions without link downtime